### PR TITLE
Add support for MediaSessionManager#getActiveSessions

### DIFF
--- a/mediacontroller/src/main/AndroidManifest.xml
+++ b/mediacontroller/src/main/AndroidManifest.xml
@@ -47,6 +47,15 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:label="@string/app_name"
+            android:name=".NotificationListener"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService"/>
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppDetails.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppDetails.java
@@ -15,31 +15,29 @@
  */
 package com.example.android.mediacontroller;
 
-import android.content.ComponentName;
 import android.graphics.Bitmap;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.v4.media.session.MediaSessionCompat;
 
 /**
  * Stores details about a media app.
  */
 public class MediaAppDetails implements Parcelable {
     public final String appName;
-    public final ComponentName mediaServiceComponentName;
     public final Bitmap icon;
+    public final MediaSessionCompat.Token sessionToken;
 
-    public MediaAppDetails(String name,
-                           ComponentName mediaServiceName,
-                           Bitmap appIcon) {
+    public MediaAppDetails(String name, Bitmap appIcon, MediaSessionCompat.Token token) {
         appName = name;
-        mediaServiceComponentName = mediaServiceName;
+        sessionToken = token;
         icon = appIcon;
     }
 
     private MediaAppDetails(final Parcel parcel) {
         appName = parcel.readString();
-        mediaServiceComponentName = parcel.readParcelable(MediaAppDetails.class.getClassLoader());
         icon = parcel.readParcelable(MediaAppDetails.class.getClassLoader());
+        sessionToken = parcel.readParcelable(MediaAppDetails.class.getClassLoader());
     }
 
     @Override
@@ -50,8 +48,8 @@ public class MediaAppDetails implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(appName);
-        dest.writeParcelable(mediaServiceComponentName, flags);
         dest.writeParcelable(icon, flags);
+        dest.writeParcelable(sessionToken, flags);
     }
 
     public static final Parcelable.Creator<MediaAppDetails> CREATOR =

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppEntry.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppEntry.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.android.mediacontroller;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
+import android.graphics.drawable.Drawable;
+import android.media.session.MediaSession;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.session.MediaSessionCompat;
+
+/**
+ * Represents a media app, used to populate entries in LaunchActivity.
+ */
+public abstract class MediaAppEntry {
+
+    public final String appName;
+    public final String packageName;
+    public final Drawable icon;
+
+    private MediaAppEntry(String name, String pkg, Drawable appIcon) {
+        appName = name;
+        packageName = pkg;
+        icon = appIcon;
+    }
+
+    /**
+     * Callback for session token, since connecting to a browse service and obtaining a session
+     * token is an asynchronous operation.
+     */
+    public interface SessionTokenAvailableCallback {
+
+        void onSuccess(MediaSessionCompat.Token sessionToken);
+
+        void onFailure();
+    }
+
+    public abstract void getSessionToken(Context context, SessionTokenAvailableCallback callback);
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MediaAppEntry that = (MediaAppEntry) o;
+        return appName.equals(that.appName) && packageName.equals(that.packageName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = appName.hashCode();
+        result = 31 * result + packageName.hashCode();
+        return result;
+    }
+
+    public static MediaAppEntry fromSessionToken(MediaSession.Token sessionToken,
+                                                 String appName,
+                                                 String packageName,
+                                                 Drawable appIcon) {
+        return new MediaAppEntry(appName, packageName, appIcon) {
+            @Override
+            public void getSessionToken(Context context, SessionTokenAvailableCallback callback) {
+                callback.onSuccess(MediaSessionCompat.Token.fromToken(sessionToken));
+            }
+        };
+    }
+
+    public static MediaAppEntry fromBrowseService(ServiceInfo serviceInfo, PackageManager pm) {
+        String appName = serviceInfo.loadLabel(pm).toString();
+        Drawable appIcon = serviceInfo.loadIcon(pm);
+        ComponentName browseService = new ComponentName(serviceInfo.packageName, serviceInfo.name);
+
+        return new MediaAppEntry(appName, serviceInfo.packageName, appIcon) {
+            private MediaBrowserCompat browser;
+
+            @Override
+            public void getSessionToken(Context context, SessionTokenAvailableCallback callback) {
+                browser = new MediaBrowserCompat(context, browseService,
+                        new MediaBrowserCompat.ConnectionCallback() {
+                            @Override
+                            public void onConnected() {
+                                callback.onSuccess(browser.getSessionToken());
+                                // Once we've obtained the session token, we no longer need to keep
+                                // an open connection to the browse service.
+                                browser.disconnect();
+                                browser = null;
+                            }
+
+                            @Override
+                            public void onConnectionFailed() {
+                                callback.onFailure();
+                            }
+                        }, null);
+                browser.connect();
+            }
+        };
+    }
+}

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppListAdapter.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppListAdapter.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.android.mediacontroller;
+
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.v7.util.DiffUtil;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.ViewHolder;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A sectioned RecyclerView Adapter that displays list(s) of media apps.
+ */
+public class MediaAppListAdapter extends RecyclerView.Adapter<ViewHolder> {
+
+    /**
+     * Click listener for when an app is selected.
+     */
+    public interface MediaAppSelectedListener {
+
+        void onMediaAppClicked(@NonNull MediaAppEntry mediaAppEntry);
+    }
+
+    /**
+     * The types of views that this recycler view adapter displays.
+     */
+    enum ViewType {
+        /**
+         * A media app entry, with icon, app name, and package name. Tapping on one of these entries
+         * will fire the MediaAppSelectedListener callback.
+         */
+        AppEntry(R.layout.media_app_item) {
+            @Override
+            ViewHolder create(ViewGroup itemLayout) {
+                return new AppEntry.ViewHolder(itemLayout);
+            }
+        },
+        /**
+         * A section header, only displayed if the adapter has multiple sections.
+         */
+        Header(R.layout.media_app_list_header) {
+            @Override
+            ViewHolder create(ViewGroup itemLayout) {
+                return new Header.ViewHolder(itemLayout);
+            }
+        },
+        /**
+         * An error, such as "no apps", or "missing permission". Can optionally provide an action.
+         */
+        Error(R.layout.media_app_list_error) {
+            @Override
+            ViewHolder create(ViewGroup itemLayout) {
+                return new Error.ViewHolder(itemLayout);
+            }
+        };
+
+        final int layoutId;
+
+        ViewType(@LayoutRes int layoutId) {
+            this.layoutId = layoutId;
+        }
+
+        abstract ViewHolder create(ViewGroup itemLayout);
+    }
+
+    /**
+     * An interface for items in the recycler view.
+     */
+    interface RecyclerViewItem {
+
+        ViewType viewType();
+
+        void bindTo(ViewHolder holder);
+    }
+
+    /**
+     * An implementation of {@link RecyclerViewItem} for media apps.
+     */
+    static class AppEntry implements RecyclerViewItem {
+
+        private final MediaAppEntry appDetails;
+        private final MediaAppSelectedListener appSelectedListener;
+
+        public AppEntry(MediaAppEntry appDetails,
+                        MediaAppSelectedListener appSelectedListener) {
+            this.appDetails = appDetails;
+            this.appSelectedListener = appSelectedListener;
+        }
+
+        @Override
+        public ViewType viewType() {
+            return ViewType.AppEntry;
+        }
+
+        @Override
+        public void bindTo(RecyclerView.ViewHolder vh) {
+            ViewHolder holder = (ViewHolder) vh;
+            holder.appIconView.setImageDrawable(appDetails.icon);
+            holder.appIconView.setContentDescription(
+                    holder.appIconView.getContext().getString(R.string.app_icon_desc, appDetails.appName));
+            holder.appNameView.setText(appDetails.appName);
+            holder.appPackageView.setText(appDetails.packageName);
+
+            holder.rootView.setOnClickListener(view ->
+                    appSelectedListener.onMediaAppClicked(appDetails));
+        }
+
+        static class ViewHolder extends RecyclerView.ViewHolder {
+            private final ViewGroup rootView;
+            private final ImageView appIconView;
+            private final TextView appNameView;
+            private final TextView appPackageView;
+
+            private ViewHolder(View itemView) {
+                super(itemView);
+                rootView = (ViewGroup) itemView;
+                appIconView = itemView.findViewById(R.id.app_icon);
+                appNameView = itemView.findViewById(R.id.app_name);
+                appPackageView = itemView.findViewById(R.id.package_name);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            AppEntry that = (AppEntry) o;
+            return appDetails.equals(that.appDetails);
+        }
+
+        @Override
+        public int hashCode() {
+            return appDetails.hashCode();
+        }
+    }
+
+    /**
+     * An implementation of {@link RecyclerViewItem} for headers.
+     */
+    static class Header implements RecyclerViewItem {
+
+        private final int labelResId;
+
+        public Header(@StringRes int label) {
+            labelResId = label;
+        }
+
+        @Override
+        public ViewType viewType() {
+            return ViewType.Header;
+        }
+
+        @Override
+        public void bindTo(RecyclerView.ViewHolder vh) {
+            ViewHolder holder = (ViewHolder) vh;
+            holder.headerView.setText(labelResId);
+        }
+
+        static class ViewHolder extends RecyclerView.ViewHolder {
+            private final TextView headerView;
+
+            private ViewHolder(View itemView) {
+                super(itemView);
+                headerView = itemView.findViewById(R.id.header_text);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Header that = (Header) o;
+            return labelResId == that.labelResId;
+        }
+
+        @Override
+        public int hashCode() {
+            return labelResId;
+        }
+    }
+
+    /**
+     * An implementation of {@link RecyclerViewItem} for error states, with an optional action.
+     */
+    static class Error implements RecyclerViewItem {
+
+        private final int errorMsgId;
+        private final int errorDetailId;
+        private final int errorButtonId;
+        private final View.OnClickListener clickListener;
+
+        public Error(@StringRes int message, @StringRes int detail, @StringRes int buttonText,
+                     @Nullable View.OnClickListener onClickListener) {
+            this.errorMsgId = message;
+            this.errorDetailId = detail;
+            this.errorButtonId = buttonText;
+            this.clickListener = onClickListener;
+        }
+
+        @Override
+        public ViewType viewType() {
+            return ViewType.Error;
+        }
+
+        @Override
+        public void bindTo(RecyclerView.ViewHolder vh) {
+            ViewHolder holder = (ViewHolder) vh;
+            holder.errorMessage.setText(errorMsgId);
+            holder.errorDetail.setText(errorDetailId);
+            holder.errorMessage.setVisibility(errorDetailId == 0 ? View.GONE : View.VISIBLE);
+            holder.actionButton.setOnClickListener(clickListener);
+            if (errorButtonId == 0 || clickListener == null) {
+                holder.actionButton.setVisibility(View.GONE);
+            } else {
+                holder.actionButton.setVisibility(View.VISIBLE);
+                holder.actionButton.setText(errorButtonId);
+            }
+        }
+
+        static class ViewHolder extends RecyclerView.ViewHolder {
+            private final TextView errorMessage;
+            private final TextView errorDetail;
+            private final Button actionButton;
+
+            private ViewHolder(View itemView) {
+                super(itemView);
+                errorMessage = itemView.findViewById(R.id.error_message);
+                errorDetail = itemView.findViewById(R.id.error_detail);
+                actionButton = itemView.findViewById(R.id.error_action);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Error that = (Error) o;
+            if (errorMsgId != that.errorMsgId) {
+                return false;
+            }
+            if (errorDetailId != that.errorDetailId) {
+                return false;
+            }
+            if (errorButtonId != that.errorButtonId) {
+                return false;
+            }
+            return clickListener != null ? clickListener.equals(that.clickListener)
+                    : that.clickListener == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = errorMsgId;
+            result = 31 * result + errorDetailId;
+            result = 31 * result + errorButtonId;
+            return result;
+        }
+    }
+
+    /**
+     * Represents a section of items in the recycler view.
+     */
+    public final class Section {
+        @StringRes
+        private final int mLabel;
+        private final List<RecyclerViewItem> mItems = new ArrayList<>();
+
+        private Section(@StringRes int label) {
+            this.mLabel = label;
+        }
+
+        public void setError(@StringRes int message, @StringRes int detail) {
+            setError(message, detail, 0, null);
+        }
+
+        public void setError(@StringRes int message, @StringRes int detail,
+                             @StringRes int buttonText, View.OnClickListener onClickListener) {
+            mItems.clear();
+            mItems.add(new Error(message, detail, buttonText, onClickListener));
+            updateData();
+        }
+
+        public void setAppsList(final List<MediaAppEntry> appEntries) {
+            mItems.clear();
+            for (MediaAppEntry appEntry : appEntries) {
+                mItems.add(new AppEntry(appEntry, mMediaAppSelectedListener));
+            }
+            updateData();
+        }
+
+    }
+
+    private final List<Section> mSections = new ArrayList<>();
+
+    private final List<RecyclerViewItem> mRecyclerViewEntries = new ArrayList<>();
+    private final MediaAppSelectedListener mMediaAppSelectedListener;
+
+    MediaAppListAdapter(@NonNull MediaAppSelectedListener itemClickListener) {
+        mMediaAppSelectedListener = itemClickListener;
+    }
+
+    Section addSection(@StringRes int label) {
+        Section section = new Section(label);
+        mSections.add(section);
+        return section;
+    }
+
+    private void updateData() {
+        final List<RecyclerViewItem> oldEntries = new ArrayList<>(mRecyclerViewEntries);
+        mRecyclerViewEntries.clear();
+        for (Section section : mSections) {
+            if (mSections.size() > 1) {
+                mRecyclerViewEntries.add(new Header(section.mLabel));
+            }
+            mRecyclerViewEntries.addAll(section.mItems);
+        }
+
+        DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(new DiffUtil.Callback() {
+            @Override
+            public int getOldListSize() {
+                return oldEntries.size();
+            }
+
+            @Override
+            public int getNewListSize() {
+                return mRecyclerViewEntries.size();
+            }
+
+            @Override
+            public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+                return oldEntries.get(oldItemPosition)
+                        .equals(mRecyclerViewEntries.get(newItemPosition));
+            }
+
+            @Override
+            public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+                return areItemsTheSame(oldItemPosition, newItemPosition);
+            }
+        });
+        diffResult.dispatchUpdatesTo(this);
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        ViewType type = ViewType.values()[viewType];
+        final ViewGroup itemLayout = (ViewGroup) LayoutInflater.from(parent.getContext())
+                .inflate(type.layoutId, parent, false);
+        return type.create(itemLayout);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder holder, int position) {
+        mRecyclerViewEntries.get(position).bindTo(holder);
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return mRecyclerViewEntries.get(position).viewType().ordinal();
+    }
+
+    @Override
+    public int getItemCount() {
+        return mRecyclerViewEntries.size();
+    }
+}

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/NotificationListener.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/NotificationListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.android.mediacontroller;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build.VERSION_CODES;
+import android.service.notification.NotificationListenerService;
+import android.support.v4.app.NotificationManagerCompat;
+
+/**
+ * A notification listener service to allows us to grab active media sessions from their
+ * notifications.
+ * This class is only used on API 21+ because the Android media framework added getActiveSessions
+ * in API 21.
+ */
+@TargetApi(VERSION_CODES.LOLLIPOP)
+public class NotificationListener extends NotificationListenerService {
+    // Helper method to check if our notification listener is enabled. In order to get active media
+    // sessions, we need an enabled notification listener component.
+    public static boolean isEnabled(Context context) {
+        return NotificationManagerCompat
+                .getEnabledListenerPackages(context)
+                .contains(context.getPackageName());
+    }
+}

--- a/mediacontroller/src/main/res/layout/activity_launch.xml
+++ b/mediacontroller/src/main/res/layout/activity_launch.xml
@@ -14,13 +14,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              tools:context="com.example.android.mediacontroller.LaunchActivity">
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    android:orientation="vertical"
+    tools:context="com.example.android.mediacontroller.LaunchActivity">
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
@@ -41,31 +44,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layoutManager=""
-        tools:visibility="gone"/>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    <LinearLayout
-        android:id="@+id/no_apps_found"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_vertical"
-        android:orientation="vertical">
+    <android.support.v4.widget.ContentLoadingProgressBar
+        android:id="@+id/spinner"
+        style="@style/Base.Widget.AppCompat.ProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:visibility="gone" />
 
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            app:srcCompat="@drawable/ic_no_apps_black_24dp"
-            tools:ignore="contentDescription"/>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/no_apps_found"
-            android:textSize="@dimen/error_text_size"/>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
-    </LinearLayout>
-</LinearLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/mediacontroller/src/main/res/layout/media_app_item.xml
+++ b/mediacontroller/src/main/res/layout/media_app_item.xml
@@ -15,26 +15,28 @@
   limitations under the License.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="72dp"
-              android:paddingBottom="@dimen/margin_small"
-              android:paddingTop="@dimen/margin_small">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/margin_small"
+    android:paddingTop="@dimen/margin_small">
 
     <ImageView
         android:id="@+id/app_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/app_icon_size"
+        android:layout_height="@dimen/app_icon_size"
         android:layout_marginEnd="@dimen/margin_small"
         android:layout_marginStart="@dimen/activity_vertical_margin"
         android:contentDescription="@string/app_icon_desc"
-        android:scaleType="centerInside"
+        android:layout_gravity="center_vertical"
+        android:scaleType="fitCenter"
         app:srcCompat="@mipmap/ic_launcher"/>
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/activity_vertical_margin"
         android:orientation="vertical">
 
         <TextView
@@ -51,7 +53,6 @@
             android:id="@+id/package_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_small"
             android:layout_marginTop="@dimen/margin_small"
             android:ellipsize="middle"
             android:textColor="@color/text_light"

--- a/mediacontroller/src/main/res/layout/media_app_list_error.xml
+++ b/mediacontroller/src/main/res/layout/media_app_list_error.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/margin_small"
+    android:paddingTop="@dimen/margin_small">
+
+    <ImageView
+        android:id="@+id/error_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_vertical_margin"
+        app:layout_constraintBottom_toBottomOf="@id/error_message"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/error_message"
+        app:srcCompat="@drawable/ic_no_apps_black_24dp"
+        tools:ignore="contentDescription" />
+
+    <TextView
+        android:id="@+id/error_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
+        android:textSize="@dimen/error_text_size"
+        app:layout_constraintBottom_toTopOf="@+id/error_detail"
+        app:layout_constraintEnd_toStartOf="@+id/error_action"
+        app:layout_constraintStart_toEndOf="@+id/error_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Error message" />
+
+    <TextView
+        android:id="@+id/error_detail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/error_details_text_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/error_action"
+        app:layout_constraintStart_toStartOf="@+id/error_message"
+        tools:text="Longer error message with more detail" />
+
+    <Button
+        android:id="@+id/error_action"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/activity_vertical_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Action" />
+
+</android.support.constraint.ConstraintLayout>

--- a/mediacontroller/src/main/res/layout/media_app_list_header.xml
+++ b/mediacontroller/src/main/res/layout/media_app_list_header.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/margin_small"
+    android:paddingBottom="@dimen/margin_small">
+
+  <TextView
+      android:id="@+id/header_text"
+      android:textStyle="bold"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/activity_vertical_margin"
+      android:layout_marginEnd="@dimen/margin_small"
+      android:gravity="center_vertical"
+      android:textColor="@color/colorPrimaryDark"
+      android:textSize="@dimen/list_header_text_size"
+      tools:text="Header"/>
+
+</LinearLayout>

--- a/mediacontroller/src/main/res/values/dimens.xml
+++ b/mediacontroller/src/main/res/values/dimens.xml
@@ -26,6 +26,8 @@
     <dimen name="control_padding">8dp</dimen>
     <dimen name="thumbs_spacing">64dp</dimen>
 
+    <dimen name="list_header_text_size">14sp</dimen>
+
     <dimen name="app_icon_size">48dp</dimen>
     <dimen name="app_name_text_size">18sp</dimen>
     <dimen name="app_package_text_size">12sp</dimen>

--- a/mediacontroller/src/main/res/values/strings.xml
+++ b/mediacontroller/src/main/res/values/strings.xml
@@ -18,8 +18,14 @@
     <string name="app_name">Media Controller Tester</string>
     <string name="app_icon_desc">App icon for %1$s.</string>
     <string name="no_apps_found">No Media Apps Found</string>
-    <string name="no_apps_details">Could not locate any apps implementing a MediaBrowser.</string>
+    <string name="no_apps_reason_no_media_browser_service">Could not locate any apps implementing a MediaBrowserService.</string>
+    <string name="no_apps_reason_no_active_sessions">Could not locate any apps with active media sessions.</string>
+    <string name="no_apps_reason_missing_permission">Notification Listener permission is required to scan for active media sessions.</string>
+    <string name="action_notification_permissions_settings">Settings</string>
     <string name="no_app_for_package">Could not find a media browser for package "%1$s".</string>
+
+    <string name="media_app_header_browse">MediaBrowserService Implementations</string>
+    <string name="media_app_header_session">Active MediaSessions</string>
 
     <string name="monkey_buttons_txt">PUSH BUTTONS!</string>
     <string name="default_pkg">com.example.android.uamp</string>
@@ -27,8 +33,7 @@
     <string name="reconnect">Reconnect</string>
     <string name="package_name_hint">Media app package name</string>
     <string name="class_name_hint">Class name of MediaBrowserService</string>
-    <string name="connection_failed_msg">MediaBrowser connection failed</string>
-    <string name="connection_suspended_msg">MediaBrowser connection suspended</string>
+    <string name="connection_failed_msg">MediaBrowser connection failed for %s</string>
     <string name="media_controller_failed_msg">Failed to create a MediaController with session token</string>
     <string name="id_hint">URI, Media ID, or Query</string>
     <string name="update_media_info">Update Media Info</string>


### PR DESCRIPTION
This allows media-controller-tester to 'connect' to currently playing media apps
even if they don't implement a MediaBrowser, by using a notification listener
service to observe media session changes.

bug: 70724823
cc: @rasekh