### PR TITLE
Improve support for custom and built-in actions

### DIFF
--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/Action.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/Action.java
@@ -23,7 +23,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaControllerCompat;
-import android.support.v4.media.session.PlaybackStateCompat;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -200,17 +199,6 @@ public class Action {
                 context.getString(R.string.action_fast_rewind));
         action.setMediaControllerAction((controller, id, extras) ->
                 controller.getTransportControls().rewind());
-        actions.add(action);
-
-        action = new Action(R.id.action_toggle_shuffle,
-                context.getString(R.string.action_toggle_shuffle));
-        action.setMediaControllerAction((controller, id, extras) -> {
-            final int shuffleMode =
-                    controller.getShuffleMode() != PlaybackStateCompat.SHUFFLE_MODE_ALL
-                            ? PlaybackStateCompat.SHUFFLE_MODE_ALL
-                            : PlaybackStateCompat.SHUFFLE_MODE_NONE;
-            controller.getTransportControls().setShuffleMode(shuffleMode);
-        });
         actions.add(action);
 
         return actions;

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/Action.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/Action.java
@@ -162,17 +162,6 @@ public class Action {
                 controller.getTransportControls().skipToPrevious());
         actions.add(action);
 
-        action = new Action(R.id.action_thumbs_up, context.getString(R.string.action_thumbs_up));
-        action.setMediaControllerAction((controller, id, extras) ->
-                controller.getTransportControls().setRating(RatingCompat.newThumbRating(true)));
-        actions.add(action);
-
-        action = new Action(R.id.action_thumbs_down,
-                context.getString(R.string.action_thumbs_down));
-        action.setMediaControllerAction((controller, id, extras) ->
-                controller.getTransportControls().setRating(RatingCompat.newThumbRating(false)));
-        actions.add(action);
-
         action = new Action(R.id.action_skip_30s_backward,
                 context.getString(R.string.action_skip_30s_backward));
         action.setMediaControllerAction((controller, id, extras) -> {

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/RatingUiHelper.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/RatingUiHelper.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.android.mediacontroller;
+
+import android.annotation.SuppressLint;
+import android.support.annotation.IdRes;
+import android.support.design.widget.TextInputLayout;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v4.media.RatingCompat;
+import android.support.v4.media.session.MediaControllerCompat;
+import android.text.Editable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.ImageView;
+
+/**
+ * Helper class to manage displaying and setting different kinds of media {@link RatingCompat}s.
+ */
+public abstract class RatingUiHelper {
+
+    /**
+     * Returns whether the given view is enabled with the current rating
+     */
+    protected abstract boolean enabled(@IdRes int viewId, RatingCompat rating);
+
+    /**
+     * Returns whether the given view is visible for the type of rating.
+     * For example, a thumbs up/down rating will not display stars or heart.
+     * And a 4-star rating will not display the fifth star.
+     */
+    protected abstract boolean visible(@IdRes int viewId);
+
+    /**
+     * Returns the rating that should be set when the given view is tapped.
+     */
+    protected abstract RatingCompat ratingFor(@IdRes int viewId, RatingCompat currentRating);
+
+    /**
+     * Returns the rating type that this RatingUiHelper handles.
+     */
+    protected abstract int ratingStyle();
+
+    private final ViewGroup rootView;
+    private final MediaControllerCompat controller;
+    private RatingCompat currentRating;
+
+    public RatingUiHelper(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+        rootView = viewGroup;
+        for (int i = 0; i < rootView.getChildCount(); ++i) {
+            View view = rootView.getChildAt(i);
+            view.setVisibility(visible(view.getId()) ? View.VISIBLE : View.GONE);
+            if (!(view instanceof Editable)) {
+                view.setOnClickListener(this::onClick);
+            }
+        }
+        controller = mediaController;
+        currentRating = unrated();
+    }
+
+    private void onClick(View view) {
+        RatingCompat newRating = ratingFor(view.getId(), currentRating);
+        controller.getTransportControls().setRating(newRating);
+        currentRating = newRating;
+    }
+
+    public void setRating(RatingCompat rating) {
+        if (rating == null) {
+            rating = unrated();
+        }
+        for (int i = 0; i < rootView.getChildCount(); ++i) {
+            View view = rootView.getChildAt(i);
+            if (view instanceof ImageView) {
+                ImageView icon = (ImageView) view;
+                final int tint = enabled(view.getId(), rating)
+                        ? R.color.colorPrimary
+                        : R.color.colorInactive;
+                DrawableCompat.setTint(icon.getDrawable(),
+                        ContextCompat.getColor(rootView.getContext(), tint));
+            } else {
+                view.setEnabled(enabled(view.getId(), rating));
+            }
+        }
+        currentRating = rating;
+    }
+
+    public RatingCompat unrated() {
+        return RatingCompat.newUnratedRating(ratingStyle());
+    }
+
+    public static class Stars3 extends RatingUiHelper {
+
+        public Stars3(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            float starRating = rating.getStarRating();
+            if (viewId == R.id.rating_star_1) {
+                return starRating >= 1.0f;
+            }
+            if (viewId == R.id.rating_star_2) {
+                return starRating >= 2.0f;
+            }
+            if (viewId == R.id.rating_star_3) {
+                return starRating >= 3.0f;
+            }
+            return false;
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            return viewId == R.id.rating_star_1
+                    || viewId == R.id.rating_star_2
+                    || viewId == R.id.rating_star_3;
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            if (viewId == R.id.rating_star_1) {
+                return stars(1);
+            }
+            if (viewId == R.id.rating_star_2) {
+                return stars(2);
+            }
+            if (viewId == R.id.rating_star_3) {
+                return stars(3);
+            }
+            return null;
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_3_STARS;
+        }
+
+        protected RatingCompat stars(int starCount) {
+            return RatingCompat.newStarRating(ratingStyle(), starCount);
+        }
+    }
+
+    public static class Stars4 extends Stars3 {
+
+        public Stars4(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            if (viewId == R.id.rating_star_4) {
+                return rating.getStarRating() >= 4.0f;
+            }
+            return super.enabled(viewId, rating);
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            if (viewId == R.id.rating_star_4) {
+                return true;
+            }
+            return super.visible(viewId);
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            if (viewId == R.id.rating_star_4) {
+                return stars(4);
+            }
+            return super.ratingFor(viewId, currentRating);
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_4_STARS;
+        }
+    }
+
+    public static class Stars5 extends Stars4 {
+
+        public Stars5(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            if (viewId == R.id.rating_star_5) {
+                return rating.getStarRating() >= 5.0f;
+            }
+            return super.enabled(viewId, rating);
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            if (viewId == R.id.rating_star_5) {
+                return true;
+            }
+            return super.visible(viewId);
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            if (viewId == R.id.rating_star_5) {
+                return stars(5);
+            }
+            return super.ratingFor(viewId, currentRating);
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_5_STARS;
+        }
+    }
+
+    public static class Thumbs extends RatingUiHelper {
+
+        public Thumbs(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            return (rating.isThumbUp() && viewId == R.id.rating_thumb_up)
+                    || (isThumbDown(rating) && viewId == R.id.rating_thumb_down);
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            return viewId == R.id.rating_thumb_up || viewId == R.id.rating_thumb_down;
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            if (enabled(viewId, currentRating)) {
+                // User tapped on current thumb rating, so reset the rating.
+                return unrated();
+            }
+            return RatingCompat.newThumbRating(viewId == R.id.rating_thumb_up);
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_THUMB_UP_DOWN;
+        }
+
+        private static boolean isThumbDown(RatingCompat rating) {
+            return rating.isRated() && !rating.isThumbUp();
+        }
+    }
+
+    public static class Heart extends RatingUiHelper {
+
+        public Heart(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            return rating.hasHeart();
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            return viewId == R.id.rating_heart;
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            return RatingCompat.newHeartRating(!currentRating.hasHeart());
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_HEART;
+        }
+    }
+
+    public static class Percentage extends RatingUiHelper {
+
+        private final EditText percentageEditText;
+
+        public Percentage(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+            percentageEditText = ((TextInputLayout) viewGroup.findViewById(R.id.rating_percentage))
+                    .getEditText();
+        }
+
+        @SuppressLint("SetTextI18n")
+        @Override
+        public void setRating(RatingCompat rating) {
+            if (rating == null) {
+                rating = unrated();
+            }
+            percentageEditText.setText(
+                    Integer.toString((int) (rating.getPercentRating() * 100), 10));
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            return true;
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            return viewId == R.id.rating_percentage || viewId == R.id.rating_percentage_set;
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            float percentage = Integer.parseInt(percentageEditText.getText().toString(), 10);
+            return RatingCompat.newPercentageRating(percentage / 100.0f);
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_PERCENTAGE;
+        }
+    }
+
+    public static class None extends RatingUiHelper {
+
+        public None(ViewGroup viewGroup, MediaControllerCompat mediaController) {
+            super(viewGroup, mediaController);
+        }
+
+        @Override
+        protected boolean enabled(int viewId, RatingCompat rating) {
+            return false;
+        }
+
+        @Override
+        protected boolean visible(int viewId) {
+            return false;
+        }
+
+        @Override
+        protected RatingCompat ratingFor(int viewId, RatingCompat currentRating) {
+            return null;
+        }
+
+        @Override
+        protected int ratingStyle() {
+            return RatingCompat.RATING_NONE;
+        }
+    }
+}

--- a/mediacontroller/src/main/res/drawable/ic_heart_black_32dp.xml
+++ b/mediacontroller/src/main/res/drawable/ic_heart_black_32dp.xml
@@ -1,0 +1,24 @@
+<!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z" />
+</vector>

--- a/mediacontroller/src/main/res/drawable/ic_repeat_black_32dp.xml
+++ b/mediacontroller/src/main/res/drawable/ic_repeat_black_32dp.xml
@@ -1,0 +1,24 @@
+<!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,7h10v3l4,-4 -4,-4v3L5,5v6h2L7,7zM17,17L7,17v-3l-4,4 4,4v-3h12v-6h-2v4z" />
+</vector>

--- a/mediacontroller/src/main/res/drawable/ic_star_black_32dp.xml
+++ b/mediacontroller/src/main/res/drawable/ic_star_black_32dp.xml
@@ -1,0 +1,24 @@
+<!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z" />
+</vector>

--- a/mediacontroller/src/main/res/layout/activity_media_app_controller.xml
+++ b/mediacontroller/src/main/res/layout/activity_media_app_controller.xml
@@ -53,6 +53,10 @@
                 android:id="@+id/controls_page"
                 layout="@layout/media_controls" />
 
+            <include
+                android:id="@+id/custom_controls_page"
+                layout="@layout/media_custom_controls" />
+
         </android.support.v4.view.ViewPager>
 
         <android.support.design.widget.TabLayout

--- a/mediacontroller/src/main/res/layout/media_controls.xml
+++ b/mediacontroller/src/main/res/layout/media_controls.xml
@@ -91,7 +91,7 @@
         android:contentDescription="@string/action_thumbs_down"
         app:layout_constraintLeft_toLeftOf="@+id/primaryGuidelineStart"
         app:layout_constraintRight_toLeftOf="@+id/centerGuideline"
-        app:layout_constraintBottom_toTopOf="@+id/action_skip_30s_backward"
+        app:layout_constraintBottom_toTopOf="@+id/group_toggle_repeat"
         app:srcCompat="@drawable/ic_thumb_down_black_32dp" />
 
     <ImageButton
@@ -107,7 +107,7 @@
         android:contentDescription="@string/action_thumbs_up"
         app:layout_constraintLeft_toLeftOf="@+id/centerGuideline"
         app:layout_constraintRight_toLeftOf="@+id/primaryGuidelineEnd"
-        app:layout_constraintBottom_toTopOf="@+id/action_skip_30s_forward"
+        app:layout_constraintBottom_toTopOf="@+id/group_toggle_shuffle"
         app:srcCompat="@drawable/ic_thumb_up_black_32dp" />
 
     <ImageButton
@@ -134,18 +134,61 @@
         app:layout_constraintStart_toStartOf="@id/centerGuideline"
         app:srcCompat="@drawable/ic_forward_30_black_32dp" />
 
-    <ImageButton
-        android:id="@+id/action_toggle_shuffle"
-        style="@style/AppTheme.MediaControl"
+    <LinearLayout
+        android:id="@+id/group_toggle_repeat"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:contentDescription="@string/action_toggle_shuffle"
+        android:layout_margin="8dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/mediaControlsGuideline"
+        app:layout_constraintEnd_toStartOf="@+id/action_skip_30s_backward"
+        app:layout_constraintLeft_toLeftOf="@+id/centerGuideline"
+        app:layout_constraintStart_toEndOf="@+id/primaryGuidelineStart">
+
+        <ImageView
+            android:id="@+id/repeat_mode_icon"
+            style="@style/AppTheme.MediaControl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_set_repeat"
+            app:srcCompat="@drawable/ic_repeat_black_32dp" />
+
+        <Spinner
+            android:id="@+id/repeat_mode"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:entries="@array/repeat_modes" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/group_toggle_shuffle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:gravity="center"
+        android:orientation="vertical"
         app:layout_constraintBottom_toTopOf="@+id/mediaControlsGuideline"
         app:layout_constraintEnd_toStartOf="@+id/primaryGuidelineEnd"
         app:layout_constraintLeft_toLeftOf="@+id/centerGuideline"
-        app:layout_constraintStart_toEndOf="@+id/action_skip_30s_forward"
-        app:srcCompat="@drawable/ic_shuffle_toggle_32dp" />
+        app:layout_constraintStart_toEndOf="@+id/action_skip_30s_forward">
+
+        <ImageView
+            android:id="@+id/shuffle_mode_icon"
+            style="@style/AppTheme.MediaControl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_set_shuffle"
+            app:srcCompat="@drawable/ic_shuffle_toggle_32dp" />
+
+        <Spinner
+            android:id="@+id/shuffle_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/shuffle_modes" />
+
+    </LinearLayout>
 
     <ImageButton
         android:id="@+id/action_skip_previous"

--- a/mediacontroller/src/main/res/layout/media_controls.xml
+++ b/mediacontroller/src/main/res/layout/media_controls.xml
@@ -75,12 +75,12 @@
         android:paddingBottom="16dp"
         app:layout_constraintLeft_toLeftOf="@+id/primaryGuidelineStart"
         app:layout_constraintRight_toLeftOf="@+id/primaryGuidelineEnd"
-        app:layout_constraintBottom_toTopOf="@+id/action_thumbs_up"
+        app:layout_constraintBottom_toTopOf="@+id/rating"
         tools:text="Album" />
 
-    <ImageButton
-        android:id="@+id/action_thumbs_down"
-        style="@style/AppTheme.MediaControl"
+    <include
+        android:id="@+id/rating"
+        layout="@layout/media_ratings"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
@@ -88,27 +88,9 @@
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginTop="8dp"
-        android:contentDescription="@string/action_thumbs_down"
         app:layout_constraintLeft_toLeftOf="@+id/primaryGuidelineStart"
-        app:layout_constraintRight_toLeftOf="@+id/centerGuideline"
         app:layout_constraintBottom_toTopOf="@+id/group_toggle_repeat"
-        app:srcCompat="@drawable/ic_thumb_down_black_32dp" />
-
-    <ImageButton
-        android:id="@+id/action_thumbs_up"
-        style="@style/AppTheme.MediaControl"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:contentDescription="@string/action_thumbs_up"
-        app:layout_constraintLeft_toLeftOf="@+id/centerGuideline"
-        app:layout_constraintRight_toLeftOf="@+id/primaryGuidelineEnd"
-        app:layout_constraintBottom_toTopOf="@+id/group_toggle_shuffle"
-        app:srcCompat="@drawable/ic_thumb_up_black_32dp" />
+        app:layout_constraintRight_toRightOf="@+id/primaryGuidelineEnd" />
 
     <ImageButton
         android:id="@+id/action_skip_30s_backward"

--- a/mediacontroller/src/main/res/layout/media_custom_control.xml
+++ b/mediacontroller/src/main/res/layout/media_custom_control.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/margin_small"
+    android:paddingTop="@dimen/margin_small">
+
+    <ImageView
+        android:id="@+id/action_icon"
+        android:layout_width="@dimen/app_icon_size"
+        android:layout_height="@dimen/app_icon_size"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="@dimen/margin_small"
+        android:scaleType="fitCenter"
+        android:tint="@color/text_dark"
+        tools:ignore="ContentDescription" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/action_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:textColor="@color/text_dark"
+            android:textSize="@dimen/app_name_text_size"
+            android:textStyle="bold"
+            tools:text="Custom Action" />
+
+        <TextView
+            android:id="@+id/action_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_small"
+            android:ellipsize="middle"
+            android:textColor="@color/text_light"
+            android:textSize="@dimen/app_package_text_size"
+            tools:text="CustomActionDescription" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/mediacontroller/src/main/res/layout/media_custom_controls.xml
+++ b/mediacontroller/src/main/res/layout/media_custom_controls.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/custom_actions_header"
+        android:textColor="@color/colorPrimaryDark"
+        android:textSize="@dimen/list_header_text_size"
+        android:textStyle="bold" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/custom_controls_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/mediacontroller/src/main/res/layout/media_ratings.xml
+++ b/mediacontroller/src/main/res/layout/media_ratings.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2018 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="horizontal">
+
+    <ImageButton
+        android:id="@+id/rating_thumb_up"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_thumb_up"
+        app:srcCompat="@drawable/ic_thumb_up_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_thumb_down"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_thumb_down"
+        app:srcCompat="@drawable/ic_thumb_down_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_heart"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_heart"
+        app:srcCompat="@drawable/ic_heart_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_star_1"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_star_1"
+        app:srcCompat="@drawable/ic_star_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_star_2"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_star_2"
+        app:srcCompat="@drawable/ic_star_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_star_3"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_star_3"
+        app:srcCompat="@drawable/ic_star_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_star_4"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_star_4"
+        app:srcCompat="@drawable/ic_star_black_32dp" />
+
+    <ImageButton
+        android:id="@+id/rating_star_5"
+        style="@style/AppTheme.MediaControl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/rating_star_5"
+        app:srcCompat="@drawable/ic_star_black_32dp" />
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/rating_percentage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="@string/rating_percentage"
+            android:maxEms="6"
+            android:minEms="4" />
+
+    </android.support.design.widget.TextInputLayout>
+
+    <Button
+        android:id="@+id/rating_percentage_set"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/rating_set_percentage" />
+
+</LinearLayout>

--- a/mediacontroller/src/main/res/values/strings.xml
+++ b/mediacontroller/src/main/res/values/strings.xml
@@ -89,6 +89,20 @@
     <string name="audio_focus_abandon_focus">Abandon</string>
     <string name="start_session_activity">Start Session Activity</string>
 
+    <string name="rating_thumb_up">Thumb Up</string>
+    <string name="rating_thumb_down">Thumb Down</string>
+
+    <string name="rating_heart">Heart</string>
+
+    <string name="rating_star_1">1 star</string>
+    <string name="rating_star_2">2 stars</string>
+    <string name="rating_star_3">3 stars</string>
+    <string name="rating_star_4">4 stars</string>
+    <string name="rating_star_5">5 stars</string>
+
+    <string name="rating_percentage">Rating %</string>
+    <string name="rating_set_percentage">Set</string>
+
     <!--
     The order of these strings must match the order of the constants
     declared in MediaAppControllerActivity.AudioFocusHelper (FOCUS_TYPES).

--- a/mediacontroller/src/main/res/values/strings.xml
+++ b/mediacontroller/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="update_media_info">Update Media Info</string>
     <string name="media_info_default">Empty Media Info</string>
     <string name="default_uri" />
+    <string name="custom_actions_header">App-provided Custom Actions</string>
 
     <string name="info_state_string">PlaybackState</string>
     <string name="info_title_string">Title</string>

--- a/mediacontroller/src/main/res/values/strings.xml
+++ b/mediacontroller/src/main/res/values/strings.xml
@@ -81,7 +81,8 @@
     <string name="action_skip_30s_forward">Skip 30s</string>
     <string name="action_skip_30s_backward">Skip back 30s</string>
 
-    <string name="action_toggle_shuffle">Toggle shuffle mode</string>
+    <string name="action_set_shuffle">Set shuffle mode</string>
+    <string name="action_set_repeat">Set repeat mode</string>
 
     <string name="audio_focus_title">Audio Focus</string>
     <string name="audio_focus_gain_focus">Gain</string>
@@ -96,5 +97,26 @@
         <item>GAIN</item>
         <item>GAIN_TRANSIENT</item>
         <item>GAIN_TRANSIENT_MAY_DUCK</item>
+    </string-array>
+
+    <!--
+    The order of these strings must match the order of the constants
+    declared in MediaAppControllerActivity.RepeatModeHelper's constructor.
+    -->
+    <string-array name="repeat_modes">
+        <item>None</item>
+        <item>One</item>
+        <item>Group</item>
+        <item>All</item>
+    </string-array>
+
+    <!--
+    The order of these strings must match the order of the constants
+    declared in MediaAppControllerActivity.ShuffleModeHelper's constructor.
+    -->
+    <string-array name="shuffle_modes">
+        <item>None</item>
+        <item>Group</item>
+        <item>All</item>
     </string-array>
 </resources>


### PR DESCRIPTION
- Added support for app-provided custom actions as a third pane in the controller activity. Displays the app-provided name, icon, and description, and executes the actions on tap.
- Changed shuffleMode from a toggle to mode-cycling and display the current shuffle mode. Also added a similar mode-cycling view for repeatMode.
- Replaced the thumbs up/thumbs down actions with a fully-fledged control that can display thumbs up/thumbs down, heart, stars, or even percentages, based on what the MediaController specifies as the rating style.