### PR TITLE
Handling release of a MediaSessionCompat

### DIFF
--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
@@ -697,6 +697,11 @@ public class MediaAppControllerActivity extends AppCompatActivity {
             onUpdate();
         }
 
+        @Override
+        public void onSessionDestroyed() {
+            showToastAndFinish("MediaSession has been released");
+        }
+
         private void onUpdate() {
             String mediaInfoStr = fetchMediaInfo();
             if (mediaInfoStr != null) {
@@ -911,7 +916,8 @@ public class MediaAppControllerActivity extends AppCompatActivity {
 
                 @Override
                 public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
-                    return actions.get(oldItemPosition).getAction()
+                    return actions.size() == mActions.size() &&
+                            actions.get(oldItemPosition).getAction()
                             .equals(mActions.get(newItemPosition).getAction());
                 }
 


### PR DESCRIPTION
MediaSession is supposed to be released in case the media application has crashed while being connected to a MediaController.
If the MediaController doesn't handle the `onSessionDestroyed()` it's possible that the old media session and old `TransportControls` are reused, which would result in a broken state.