### PR TITLE
Update Kotlin to version 1.3.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@
 buildscript {
     ext {
         constraint_layout_version = '1.1.2'
-        kotlin_version = '1.2.30'
+        kotlin_version = '1.3.31'
         support_lib_version = '27.1.1'
     }
 
@@ -29,7 +29,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 13 10:26:08 KST 2018
+#Wed Apr 17 08:46:17 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/mediacontroller/build.gradle
+++ b/mediacontroller/build.gradle
@@ -20,7 +20,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
**Resolved error:**
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.0 and higher.
The following dependencies do not satisfy the required version:
root project 'android-media-controller' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.30

**Resolved warning:**
WARNING: The specified Android SDK Build Tools version (27.0.3) is ignored, as
it is below the minimum supported version (28.0.3) for Android Gradle Plugin
3.3.2.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '27.0.3'" from your
build.gradle file, as each version of the Android Gradle Plugin now has a
default version of the build tools.