### PR TITLE
Don't tint icons of app-provided media items

### DIFF
--- a/mediacontroller/src/main/res/layout/media_browse_item.xml
+++ b/mediacontroller/src/main/res/layout/media_browse_item.xml
@@ -27,7 +27,6 @@
         android:layout_gravity="center_vertical"
         android:layout_marginEnd="@dimen/margin_small"
         android:scaleType="fitCenter"
-        android:tint="@color/text_dark"
         tools:ignore="ContentDescription" />
 
     <LinearLayout


### PR DESCRIPTION
Tinting only makes sense for icons which are known to be monochrome/transparent. The app-provided media icons, however, will also show colored album art and logo bitmaps which turn into black filled squares when tinted.

This can be tested e.g. with VLC and RadioDroid2.