### PR TITLE
Format and render `android.media.extra` metadata

### DIFF
--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/TestUtils.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/TestUtils.kt
@@ -15,6 +15,7 @@
  */
 package com.example.android.mediacontroller
 
+import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
@@ -26,6 +27,7 @@ import org.json.JSONObject
  */
 
 const val METADATA_KEY_PREFIX = "android.media.metadata."
+const val METADATA_EXTRA_KEY_PREFIX = "android.media.extra."
 
 // Title, Artist, and Duration seem to always be present for a given Media Item, so these
 // three Metadata Keys are used to identify unique Media Items
@@ -262,7 +264,12 @@ fun getMetadataKey(metadata: MediaMetadataCompat?, key: String): String {
             MediaMetadataCompat.METADATA_KEY_DISC_NUMBER,
             MediaMetadataCompat.METADATA_KEY_DURATION,
             MediaMetadataCompat.METADATA_KEY_NUM_TRACKS,
-            MediaMetadataCompat.METADATA_KEY_TRACK_NUMBER
+            MediaMetadataCompat.METADATA_KEY_TRACK_NUMBER,
+            MediaMetadataCompat.METADATA_KEY_DOWNLOAD_STATUS,
+            MediaMetadataCompat.METADATA_KEY_BT_FOLDER_TYPE,
+            MediaMetadataCompat.METADATA_KEY_ADVERTISEMENT,
+            MediaDescriptionCompat.EXTRA_DOWNLOAD_STATUS,
+            MediaDescriptionCompat.EXTRA_BT_FOLDER_TYPE
     )
     val bitmapValues = arrayOf(
             MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
@@ -302,6 +309,8 @@ fun formatMetadata(metadata: MediaMetadataCompat?): String {
     keys.forEach { key ->
         val label = if (key.startsWith(METADATA_KEY_PREFIX)) {
             "${key.substringAfter(METADATA_KEY_PREFIX)}:".padEnd(20, ' ')
+        } else if (key.startsWith(METADATA_EXTRA_KEY_PREFIX)) {
+            "extra.${key.substringAfter(METADATA_EXTRA_KEY_PREFIX)}:".padEnd(20, ' ')
         } else {
             "$key:".padEnd(20, ' ')
         }


### PR DESCRIPTION
According to [Android Auto's docs](https://developer.android.com/training/cars/media#metadata-indicators) for metadata indicators, there are a few more extras that should be exposed for a complete UI rendering that `android-media-controller` doesn't take in account.

I'm updating the code to consider `DOWNLOAD_STATUS`, `BT_FOLDER_TYPE` and `METADATA_KEY_ADVERTISEMENT`, and render them as `Long` values in the "test" screen. See screenshots.

![Screenshot_1562852776](https://user-images.githubusercontent.com/1541701/61057173-06ecad80-a3f5-11e9-8590-d7bad555e0f1.png)
