### PR TITLE
Fix issue with androidX library and support library.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,5 +31,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.enableJetifier=true
 android.useAndroidX=true


### PR DESCRIPTION
When app uses support library we have different objects when we use search method.

It can be reproduced when we try to search in app which uses support library for MediaBrowserCompat.SearchCallback.  Media controller doesn't receive any callback because app expects  MediaBrowserCompat.SearchCallback from support library but receive from androidx