### PR TITLE
Pass the extras bundle to the playFromMediaId instead of null

### DIFF
--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
@@ -1143,7 +1143,7 @@ public class MediaAppControllerActivity extends AppCompatActivity {
                         }
                         if (item.isPlayable() && mController != null) {
                             mController.getTransportControls().playFromMediaId(item.getMediaId(),
-                                    null);
+                                    item.getDescription().getExtras());
                         }
                     });
         }


### PR DESCRIPTION
When setting the extras on the description of a `MediaItem` we expect the same bundle to be passed along on `playFromMediaId`.

Correct me if I am wrong, but that is the behaviour we observe on the android automotive and android auto and wanted to make it consistent.