### PR TITLE
[Infra] Add config options

### DIFF
--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestSuite.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestSuite.kt
@@ -46,7 +46,7 @@ import java.util.concurrent.Semaphore
 import kotlin.concurrent.thread
 
 
-class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, testList: Array<TestOptionDetails>, private val testSuiteResultsLayout: RecyclerView, context: Context){
+class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, testList: Array<TestOptionDetails>, private val testSuiteResultsLayout: RecyclerView, context: Context) {
     val name = testSuiteName
     val description = testSuiteDescription
     private val singleSuiteTestList = testList
@@ -60,7 +60,6 @@ class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, tes
     private var screenHeight = 0
     private val SLEEP_TIME = 1000L
     private val sharedPreferences: SharedPreferences
-
 
     init {
         for (i in testList.indices) {
@@ -81,8 +80,8 @@ class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, tes
 
     fun getConfigurableTests(): ArrayList<TestOptionDetails> {
         var configTests = ArrayList<TestOptionDetails>()
-        for(test in singleSuiteTestList){
-            if(test.queryRequired){
+        for (test in singleSuiteTestList) {
+            if (test.queryRequired) {
                 configTests.add(test)
             }
         }
@@ -102,14 +101,13 @@ class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, tes
                 // Flush out any residual media control commands from previous test
                 Thread.sleep(SLEEP_TIME)
 
-
                 // In the event that a query is not specified, don't run the test.
                 var query = sharedPreferences.getString(test.name, MediaAppTestingActivity.NO_CONFIG)
                 if (test.queryRequired && query == MediaAppTestingActivity.NO_CONFIG) {
-                        test.testResult = TestResult.CONFIG_REQUIRED
-                        val index = iDToPositionMap[test.id]
-                        mHandler.post { resultsAdapter.notifyItemChanged(index!!) }
-                        continue
+                    test.testResult = TestResult.CONFIG_REQUIRED
+                    val index = iDToPositionMap[test.id]
+                    mHandler.post { resultsAdapter.notifyItemChanged(index!!) }
+                    continue
                 }
 
                 // For tests that don't require queries, run normally.
@@ -191,7 +189,6 @@ class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, tes
     inner class OnResultsClickedListener(private val testDetails: TestOptionDetails, val context: Context) : View.OnClickListener {
 
         override fun onClick(p0: View?) {
-
             var dialog = Dialog(context)
             dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
             dialog.setContentView(R.layout.test_suite_results_dialog)

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestSuite.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestSuite.kt
@@ -21,13 +21,11 @@ import android.content.SharedPreferences
 import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
-import android.util.DisplayMetrics
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import android.view.WindowManager
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.ScrollView
@@ -46,7 +44,9 @@ import java.util.concurrent.Semaphore
 import kotlin.concurrent.thread
 
 
-class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, testList: Array<TestOptionDetails>, private val testSuiteResultsLayout: RecyclerView, context: Context) {
+class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, testList:
+    Array<TestOptionDetails>, private val testSuiteResultsLayout: RecyclerView, context: Context) {
+
     val name = testSuiteName
     val description = testSuiteDescription
     private val singleSuiteTestList = testList
@@ -110,7 +110,9 @@ class MediaAppTestSuite(testSuiteName: String, testSuiteDescription: String, tes
                     continue
                 }
 
-                // For tests that don't require queries, run normally.
+                if (query == MediaAppTestingActivity.NO_CONFIG){
+                    query = ""
+                }
                 testSemaphore.acquire()
                 test.runTest(query, callback, test.id)
             }

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
@@ -34,7 +34,13 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.DisplayMetrics
 import android.util.Log
-import android.view.*
+import android.view.View
+import android.view.ViewGroup
+import android.view.MenuItem
+import android.view.Menu
+import android.view.LayoutInflater
+import android.view.Window
+import android.view.WindowManager
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -422,7 +428,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
             val testSuite = testSuites[position]
             holder.cardView.card_header.text = testSuite.name
             holder.cardView.card_text.text = testSuite.description
-            holder.cardView.card_button.text = "Run Suite"
+            holder.cardView.card_button.text = resources.getText(R.string.run_suite_button)
 
             val configurableTests = testSuite.getConfigurableTests()
             if (!configurableTests.isEmpty()) {
@@ -1193,11 +1199,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
 
         private const val TAG = "MediaAppTestingActivity"
 
-        // Shared pref key name for test suite config
-        const val SHARED_PREF_KEY_SUITE_CONFIG = ""
 
-        // Shared pref suite no configuration setup
-        const val NO_CONFIG = ""
 
         // Key names for external extras.
         private const val PACKAGE_NAME_EXTRA = "com.example.android.mediacontroller.PACKAGE_NAME"
@@ -1209,6 +1211,12 @@ class MediaAppTestingActivity : AppCompatActivity() {
         // Key name used for saving/restoring instance state.
         private const val STATE_APP_DETAILS_KEY =
                 "com.example.android.mediacontroller.STATE_APP_DETAILS_KEY"
+
+        // Shared pref key name for test suite config
+        const val SHARED_PREF_KEY_SUITE_CONFIG = ""
+
+        // Shared pref suite no configuration setup
+        const val NO_CONFIG = ""
 
         /**
          * Builds an [Intent] to launch this Activity with a set of extras.
@@ -1226,6 +1234,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
             return intent
         }
 
+        // Gets the current screen height in pixels
         fun getScreenHeightPx(context: Context): Int {
             val displayMetrics = DisplayMetrics()
             val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
@@ -161,7 +161,6 @@ class MediaAppTestingActivity : AppCompatActivity() {
     }
 
 
-
     override fun onDestroy() {
         mediaController?.run {
             unregisterCallback(controllerCallback)
@@ -426,9 +425,9 @@ class MediaAppTestingActivity : AppCompatActivity() {
             holder.cardView.card_button.text = "Run Suite"
 
             val configurableTests = testSuite.getConfigurableTests()
-            if(!configurableTests.isEmpty()){
+            if (!configurableTests.isEmpty()) {
                 holder.cardView.configure_test_suite_button.visibility = View.VISIBLE
-                holder.cardView.configure_test_suite_button.setOnClickListener{
+                holder.cardView.configure_test_suite_button.setOnClickListener {
                     val configAdapter = ConfigurationAdapter(configurableTests)
 
                     var dialog = Dialog(this@MediaAppTestingActivity)
@@ -442,7 +441,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
                     val sharedPreferences = getSharedPreferences(SHARED_PREF_KEY_SUITE_CONFIG, Context.MODE_PRIVATE)
 
                     // Reset config button clicked
-                    dialog.reset_results_button.setOnClickListener{
+                    dialog.reset_results_button.setOnClickListener {
                         sharedPreferences.edit().apply {
                             for (i in configurableTests.indices) {
                                 putString(configurableTests[i].name, NO_CONFIG)
@@ -453,7 +452,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
                     }
 
                     // Done button pressed
-                    dialog.done_button.setOnClickListener{
+                    dialog.done_button.setOnClickListener {
                         dialog.dismiss()
                     }
                     dialog.show()
@@ -509,7 +508,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
             holder.cardView.test_query_config.addTextChangedListener(object : TextWatcher {
 
                 override fun afterTextChanged(s: Editable) {
-                    sharedPreferences.edit().apply{
+                    sharedPreferences.edit().apply {
                         putString(test.name, holder.cardView.test_query_config.text.toString())
                     }.apply()
                 }
@@ -525,7 +524,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
 
             val previousConfig = sharedPreferences.getString(test.name, NO_CONFIG)
             holder.cardView.test_query_config.setText((previousConfig))
-            if (previousConfig == NO_CONFIG){
+            if (previousConfig == NO_CONFIG) {
                 holder.cardView.test_query_config.setText("")
                 holder.cardView.test_query_config.hint = "Query"
                 return
@@ -1195,7 +1194,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
         private const val TAG = "MediaAppTestingActivity"
 
         // Shared pref key name for test suite config
-        const val SHARED_PREF_KEY_SUITE_CONFIG = "mct-shared-pref"
+        const val SHARED_PREF_KEY_SUITE_CONFIG = ""
 
         // Shared pref suite no configuration setup
         const val NO_CONFIG = ""

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
@@ -16,6 +16,8 @@
 package com.example.android.mediacontroller
 
 import android.app.Activity
+import android.app.Dialog
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color
@@ -28,12 +30,11 @@ import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.DisplayMetrics
 import android.util.Log
-import android.view.View
-import android.view.ViewGroup
-import android.view.MenuItem
-import android.view.Menu
-import android.view.LayoutInflater
+import android.view.*
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -50,11 +51,13 @@ import androidx.viewpager.widget.PagerAdapter
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.android.synthetic.main.activity_media_app_testing.*
+import kotlinx.android.synthetic.main.config_item.view.*
 import kotlinx.android.synthetic.main.media_controller_info.*
 import kotlinx.android.synthetic.main.media_queue_item.view.*
 import kotlinx.android.synthetic.main.media_test_option.view.*
 import kotlinx.android.synthetic.main.media_test_suites.*
 import kotlinx.android.synthetic.main.media_tests.*
+import kotlinx.android.synthetic.main.test_suite_configure_dialog.*
 
 class MediaAppTestingActivity : AppCompatActivity() {
     private var mediaAppDetails: MediaAppDetails? = null
@@ -85,7 +88,6 @@ class MediaAppTestingActivity : AppCompatActivity() {
         toolbar.setNavigationOnClickListener { finish() }
 
         Test.androidResources = resources
-
         bottomNavigationView = findViewById(R.id.bottom_navigation_view)
         viewPager = view_pager
         testsQuery = tests_query
@@ -157,6 +159,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
             }
         })
     }
+
 
 
     override fun onDestroy() {
@@ -417,10 +420,46 @@ class MediaAppTestingActivity : AppCompatActivity() {
 
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            holder.cardView.card_header.text = testSuites[position].name
-            holder.cardView.card_text.text = testSuites[position].description
+            val testSuite = testSuites[position]
+            holder.cardView.card_header.text = testSuite.name
+            holder.cardView.card_text.text = testSuite.description
             holder.cardView.card_button.text = "Run Suite"
-            var suiteRunning = false
+
+            val configurableTests = testSuite.getConfigurableTests()
+            if(!configurableTests.isEmpty()){
+                holder.cardView.configure_test_suite_button.visibility = View.VISIBLE
+                holder.cardView.configure_test_suite_button.setOnClickListener{
+                    val configAdapter = ConfigurationAdapter(configurableTests)
+
+                    var dialog = Dialog(this@MediaAppTestingActivity)
+                    dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+                    dialog.setContentView(R.layout.test_suite_configure_dialog)
+                    dialog.title.text = testSuite.name + " Configuration"
+                    dialog.subtitle.text = testSuite.description
+                    dialog.test_to_configure_list.layoutManager = LinearLayoutManager(this@MediaAppTestingActivity)
+                    dialog.test_to_configure_list.layoutParams.height = getScreenHeightPx(this@MediaAppTestingActivity) / 2
+                    dialog.test_to_configure_list.adapter = configAdapter
+                    val sharedPreferences = getSharedPreferences(SHARED_PREF_KEY_SUITE_CONFIG, Context.MODE_PRIVATE)
+
+                    // Reset config button clicked
+                    dialog.reset_results_button.setOnClickListener{
+                        sharedPreferences.edit().apply {
+                            for (i in configurableTests.indices) {
+                                putString(configurableTests[i].name, NO_CONFIG)
+                                configAdapter.notifyItemChanged(i)
+                            }
+                        }.apply()
+                        dialog.dismiss()
+                    }
+
+                    // Done button pressed
+                    dialog.done_button.setOnClickListener{
+                        dialog.dismiss()
+                    }
+                    dialog.show()
+                }
+            }
+
             holder.cardView.card_button.setOnClickListener {
                 var numIter = test_suite_num_iter.text.toString().toIntOrNull()
                 if (numIter == null) {
@@ -429,7 +468,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
                 } else if (numIter > 100 || numIter < 1) {
                     Toast.makeText(this@MediaAppTestingActivity, getText(R.string.test_suite_error_invalid_iter), Toast.LENGTH_SHORT).show()
                 } else if (isSuiteRunning()) {
-                    Toast.makeText(applicationContext, getText(R.string.test_suite_already_running), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MediaAppTestingActivity, getText(R.string.test_suite_already_running), Toast.LENGTH_SHORT).show()
                 } else {
                     testSuites[position].runSuite(numIter)
                 }
@@ -446,6 +485,54 @@ class MediaAppTestingActivity : AppCompatActivity() {
             }
             return false
         }
+    }
+
+    // Adapter to display test suite details
+    inner class ConfigurationAdapter(
+            private val tests: ArrayList<TestOptionDetails>
+    ) : RecyclerView.Adapter<ConfigurationAdapter.ViewHolder>() {
+        inner class ViewHolder(val cardView: CardView) : RecyclerView.ViewHolder(cardView)
+
+        override fun onCreateViewHolder(
+                parent: ViewGroup,
+                viewType: Int
+        ): ConfigurationAdapter.ViewHolder {
+            val cardView = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.config_item, parent, false) as CardView
+            return ViewHolder(cardView)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val test = tests[position]
+            holder.cardView.test_name_config.text = test.name
+            val sharedPreferences = getSharedPreferences(SHARED_PREF_KEY_SUITE_CONFIG, Context.MODE_PRIVATE)
+            holder.cardView.test_query_config.addTextChangedListener(object : TextWatcher {
+
+                override fun afterTextChanged(s: Editable) {
+                    sharedPreferences.edit().apply{
+                        putString(test.name, holder.cardView.test_query_config.text.toString())
+                    }.apply()
+                }
+
+                override fun beforeTextChanged(s: CharSequence, start: Int,
+                                               count: Int, after: Int) {
+                }
+
+                override fun onTextChanged(s: CharSequence, start: Int,
+                                           before: Int, count: Int) {
+                }
+            })
+
+            val previousConfig = sharedPreferences.getString(test.name, NO_CONFIG)
+            holder.cardView.test_query_config.setText((previousConfig))
+            if (previousConfig == NO_CONFIG){
+                holder.cardView.test_query_config.setText("")
+                holder.cardView.test_query_config.hint = "Query"
+                return
+            }
+        }
+
+        override fun getItemCount() = tests.size
     }
 
     private fun setupTests() {
@@ -1104,7 +1191,14 @@ class MediaAppTestingActivity : AppCompatActivity() {
             }
 
     companion object {
+
         private const val TAG = "MediaAppTestingActivity"
+
+        // Shared pref key name for test suite config
+        const val SHARED_PREF_KEY_SUITE_CONFIG = "mct-shared-pref"
+
+        // Shared pref suite no configuration setup
+        const val NO_CONFIG = ""
 
         // Key names for external extras.
         private const val PACKAGE_NAME_EXTRA = "com.example.android.mediacontroller.PACKAGE_NAME"
@@ -1131,6 +1225,14 @@ class MediaAppTestingActivity : AppCompatActivity() {
             val intent = Intent(activity, MediaAppTestingActivity::class.java)
             intent.putExtra(APP_DETAILS_EXTRA, appDetails)
             return intent
+        }
+
+        fun getScreenHeightPx(context: Context): Int {
+            val displayMetrics = DisplayMetrics()
+            val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            val display = windowManager.defaultDisplay
+            display.getMetrics(displayMetrics)
+            return displayMetrics.heightPixels
         }
     }
 }

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
@@ -55,15 +55,45 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager.widget.PagerAdapter
 import androidx.viewpager.widget.ViewPager
+
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import kotlinx.android.synthetic.main.activity_media_app_testing.*
-import kotlinx.android.synthetic.main.config_item.view.*
-import kotlinx.android.synthetic.main.media_controller_info.*
-import kotlinx.android.synthetic.main.media_queue_item.view.*
-import kotlinx.android.synthetic.main.media_test_option.view.*
-import kotlinx.android.synthetic.main.media_test_suites.*
-import kotlinx.android.synthetic.main.media_tests.*
-import kotlinx.android.synthetic.main.test_suite_configure_dialog.*
+import kotlinx.android.synthetic.main.activity_media_app_testing.media_controller_test_page
+import kotlinx.android.synthetic.main.activity_media_app_testing.media_controller_test_suite_page
+import kotlinx.android.synthetic.main.activity_media_app_testing.media_controller_info_page
+import kotlinx.android.synthetic.main.activity_media_app_testing.toolbar
+import kotlinx.android.synthetic.main.activity_media_app_testing.view_pager
+import kotlinx.android.synthetic.main.config_item.view.test_name_config
+import kotlinx.android.synthetic.main.config_item.view.test_query_config
+import kotlinx.android.synthetic.main.media_controller_info.queue_item_list
+import kotlinx.android.synthetic.main.media_controller_info.connection_error_text
+import kotlinx.android.synthetic.main.media_controller_info.metadata_text
+import kotlinx.android.synthetic.main.media_controller_info.playback_state_text
+import kotlinx.android.synthetic.main.media_controller_info.queue_text
+import kotlinx.android.synthetic.main.media_controller_info.repeat_mode_text
+import kotlinx.android.synthetic.main.media_controller_info.queue_title_text
+import kotlinx.android.synthetic.main.media_controller_info.shuffle_mode_text
+import kotlinx.android.synthetic.main.media_queue_item.view.queue_id
+import kotlinx.android.synthetic.main.media_queue_item.view.description_title
+import kotlinx.android.synthetic.main.media_queue_item.view.description_subtitle
+import kotlinx.android.synthetic.main.media_queue_item.view.description_id
+import kotlinx.android.synthetic.main.media_queue_item.view.description_uri
+import kotlinx.android.synthetic.main.media_test_option.view.configure_test_suite_button
+import kotlinx.android.synthetic.main.media_test_option.view.card_text
+import kotlinx.android.synthetic.main.media_test_option.view.card_header
+import kotlinx.android.synthetic.main.media_test_option.view.card_button
+
+import kotlinx.android.synthetic.main.media_test_suites.test_suite_options_list
+import kotlinx.android.synthetic.main.media_test_suites.test_suite_results_container
+import kotlinx.android.synthetic.main.media_test_suites.test_suite_num_iter
+import kotlinx.android.synthetic.main.media_tests.test_results_container
+import kotlinx.android.synthetic.main.media_tests.tests_query
+import kotlinx.android.synthetic.main.media_tests.test_options_list
+import kotlinx.android.synthetic.main.test_suite_configure_dialog.test_to_configure_list
+import kotlinx.android.synthetic.main.test_suite_configure_dialog.reset_results_button
+import kotlinx.android.synthetic.main.test_suite_configure_dialog.subtitle
+import kotlinx.android.synthetic.main.test_suite_configure_dialog.title
+import kotlinx.android.synthetic.main.test_suite_configure_dialog.done_button
+
 
 class MediaAppTestingActivity : AppCompatActivity() {
     private var mediaAppDetails: MediaAppDetails? = null
@@ -435,33 +465,33 @@ class MediaAppTestingActivity : AppCompatActivity() {
                 holder.cardView.configure_test_suite_button.visibility = View.VISIBLE
                 holder.cardView.configure_test_suite_button.setOnClickListener {
                     val configAdapter = ConfigurationAdapter(configurableTests)
-
-                    var dialog = Dialog(this@MediaAppTestingActivity)
-                    dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-                    dialog.setContentView(R.layout.test_suite_configure_dialog)
-                    dialog.title.text = testSuite.name + " Configuration"
-                    dialog.subtitle.text = testSuite.description
-                    dialog.test_to_configure_list.layoutManager = LinearLayoutManager(this@MediaAppTestingActivity)
-                    dialog.test_to_configure_list.layoutParams.height = getScreenHeightPx(this@MediaAppTestingActivity) / 2
-                    dialog.test_to_configure_list.adapter = configAdapter
                     val sharedPreferences = getSharedPreferences(SHARED_PREF_KEY_SUITE_CONFIG, Context.MODE_PRIVATE)
+                    Dialog(this@MediaAppTestingActivity).apply {
+                        // Init dialog
+                        requestWindowFeature(Window.FEATURE_NO_TITLE)
+                        setContentView(R.layout.test_suite_configure_dialog)
+                        title.text = testSuite.name + " Configuration"
+                        subtitle.text = testSuite.description
+                        test_to_configure_list.layoutManager = LinearLayoutManager(this@MediaAppTestingActivity)
+                        test_to_configure_list.layoutParams.height = getScreenHeightPx(this@MediaAppTestingActivity) / 2
+                        test_to_configure_list.adapter = configAdapter
 
-                    // Reset config button clicked
-                    dialog.reset_results_button.setOnClickListener {
-                        sharedPreferences.edit().apply {
-                            for (i in configurableTests.indices) {
-                                putString(configurableTests[i].name, NO_CONFIG)
-                                configAdapter.notifyItemChanged(i)
-                            }
-                        }.apply()
-                        dialog.dismiss()
-                    }
+                        // Reset config button clicked
+                        reset_results_button.setOnClickListener {
+                            sharedPreferences.edit().apply {
+                                for (i in configurableTests.indices) {
+                                    putString(configurableTests[i].name, NO_CONFIG)
+                                    configAdapter.notifyItemChanged(i)
+                                }
+                            }.apply()
+                            dismiss()
+                        }
 
-                    // Done button pressed
-                    dialog.done_button.setOnClickListener {
-                        dialog.dismiss()
-                    }
-                    dialog.show()
+                        // Done button pressed
+                        done_button.setOnClickListener {
+                            dismiss()
+                        }
+                    }.show()
                 }
             }
 
@@ -520,12 +550,10 @@ class MediaAppTestingActivity : AppCompatActivity() {
                 }
 
                 override fun beforeTextChanged(s: CharSequence, start: Int,
-                                               count: Int, after: Int) {
-                }
+                                               count: Int, after: Int) = Unit
 
                 override fun onTextChanged(s: CharSequence, start: Int,
-                                           before: Int, count: Int) {
-                }
+                                           before: Int, count: Int) = Unit
             })
 
             val previousConfig = sharedPreferences.getString(test.name, NO_CONFIG)
@@ -1199,8 +1227,6 @@ class MediaAppTestingActivity : AppCompatActivity() {
 
         private const val TAG = "MediaAppTestingActivity"
 
-
-
         // Key names for external extras.
         private const val PACKAGE_NAME_EXTRA = "com.example.android.mediacontroller.PACKAGE_NAME"
 
@@ -1213,10 +1239,10 @@ class MediaAppTestingActivity : AppCompatActivity() {
                 "com.example.android.mediacontroller.STATE_APP_DETAILS_KEY"
 
         // Shared pref key name for test suite config
-        const val SHARED_PREF_KEY_SUITE_CONFIG = ""
+        const val SHARED_PREF_KEY_SUITE_CONFIG = "mct-test-suite-config"
 
         // Shared pref suite no configuration setup
-        const val NO_CONFIG = ""
+        const val NO_CONFIG = "no-conf"
 
         /**
          * Builds an [Intent] to launch this Activity with a set of extras.
@@ -1237,7 +1263,7 @@ class MediaAppTestingActivity : AppCompatActivity() {
         // Gets the current screen height in pixels
         fun getScreenHeightPx(context: Context): Int {
             val displayMetrics = DisplayMetrics()
-            val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            val windowManager = ContextCompat.getSystemService(context, WindowManager::class.java)
             val display = windowManager.defaultDisplay
             display.getMetrics(displayMetrics)
             return displayMetrics.heightPixels

--- a/mediacontroller/src/main/res/layout/config_item.xml
+++ b/mediacontroller/src/main/res/layout/config_item.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <!--
+      Copyright (C) 2018 The Android Open Source Project
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+      -->
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/card_view_config"
+    android:layout_gravity="center"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/margin_small"
+    card_view:cardBackgroundColor="@color/cardview_light_background"
+    card_view:cardCornerRadius="4dp">
+
+    <LinearLayout
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:weightSum="5">
+        <TextView
+            android:id="@+id/test_name_config"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/tests_subheader_text_size"/>
+        <EditText
+            android:id="@+id/test_query_config"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/query_hint"
+            android:textSize="@dimen/tests_subheader_text_size"/>
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/mediacontroller/src/main/res/layout/config_item.xml
+++ b/mediacontroller/src/main/res/layout/config_item.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-    <!--
-      Copyright (C) 2018 The Android Open Source Project
+<!--
+  Copyright (C) 2020 The Android Open Source Project
 
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-           http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-      -->
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -30,17 +30,19 @@
         android:layout_width="match_parent"
         android:orientation="vertical"
         android:weightSum="5">
+
         <TextView
             android:id="@+id/test_name_config"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/tests_subheader_text_size"/>
+            android:textSize="@dimen/tests_subheader_text_size" />
+
         <EditText
             android:id="@+id/test_query_config"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/query_hint"
-            android:textSize="@dimen/tests_subheader_text_size"/>
+            android:textSize="@dimen/tests_subheader_text_size" />
 
     </LinearLayout>
 

--- a/mediacontroller/src/main/res/layout/media_test_option.xml
+++ b/mediacontroller/src/main/res/layout/media_test_option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright (C) 2018 The Android Open Source Project
+  Copyright (C) 2020 The Android Open Source Project
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -38,13 +38,14 @@
             tools:text="Test Name"
             android:textSize="@dimen/tests_subheader_text_size"
             android:textStyle="italic"
-            android:textColor="#000"/>
+            android:textColor="#000" />
 
         <TextView
             android:id="@+id/card_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="Test Description"/>
+            tools:text="Test Description" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/mediacontroller/src/main/res/layout/media_test_option.xml
+++ b/mediacontroller/src/main/res/layout/media_test_option.xml
@@ -45,13 +45,30 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Test Description"/>
-
-        <Button
-            android:id="@+id/card_button"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/tests_run_button" />
+            android:orientation="horizontal"
+            android:gravity="right"
+            android:weightSum="10">
+
+            <Button
+                android:id="@+id/configure_test_suite_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="invisible"
+                android:layout_gravity="end"
+                android:layout_weight="1"
+                android:text="@string/configure_button" />
+
+            <Button
+                android:id="@+id/card_button"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:text="@string/tests_run_button" />
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/mediacontroller/src/main/res/layout/test_suite_configure_dialog.xml
+++ b/mediacontroller/src/main/res/layout/test_suite_configure_dialog.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2020 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:id="@+id/test_suite_configure_dialog"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="@dimen/margin_small"
+        android:textStyle="bold"
+        android:textSize="@dimen/tests_header_text_size"
+        />
+
+    <TextView
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="@dimen/tests_subheader_text_size"
+       />
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:padding="@dimen/margin_small"
+        android:background="@color/colorPrimary"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/test_to_configure_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        android:background="@color/background_grey"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/reset_results_button"
+            android:layout_width="match_parent"
+            android:background="@color/colorPrimary"
+            android:textColor="@color/background_white"
+            android:layout_height="match_parent"
+            android:text="@string/reset_button_text"
+            android:layout_margin="@dimen/margin_small"
+            android:layout_weight="1"
+            />
+
+        <Button
+            android:id="@+id/done_button"
+            android:layout_width="match_parent"
+            android:background="@color/colorPrimary"
+            android:textColor="@color/background_white"
+            android:layout_height="match_parent"
+            android:text="@string/done_configure_button"
+            android:layout_margin="@dimen/margin_small"
+            android:layout_weight="1"
+            />
+
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/mediacontroller/src/main/res/layout/test_suite_configure_dialog.xml
+++ b/mediacontroller/src/main/res/layout/test_suite_configure_dialog.xml
@@ -14,12 +14,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:id="@+id/test_suite_configure_dialog"
     android:layout_height="match_parent"
     android:orientation="vertical">
+
     <TextView
         android:id="@+id/title"
         android:layout_width="match_parent"
@@ -27,28 +27,27 @@
         android:gravity="center"
         android:padding="@dimen/margin_small"
         android:textStyle="bold"
-        android:textSize="@dimen/tests_header_text_size"
-        />
+        android:textSize="@dimen/tests_header_text_size" />
 
     <TextView
         android:id="@+id/subtitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:textSize="@dimen/tests_subheader_text_size"
-       />
+        android:textSize="@dimen/tests_subheader_text_size" />
+
     <View
         android:layout_width="match_parent"
         android:layout_height="2dp"
         android:padding="@dimen/margin_small"
-        android:background="@color/colorPrimary"/>
+        android:background="@color/colorPrimary" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/test_to_configure_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fillViewport="true"
-        android:background="@color/background_grey"/>
+        android:background="@color/background_grey" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -63,8 +62,7 @@
             android:layout_height="match_parent"
             android:text="@string/reset_button_text"
             android:layout_margin="@dimen/margin_small"
-            android:layout_weight="1"
-            />
+            android:layout_weight="1" />
 
         <Button
             android:id="@+id/done_button"
@@ -74,8 +72,7 @@
             android:layout_height="match_parent"
             android:text="@string/done_configure_button"
             android:layout_margin="@dimen/margin_small"
-            android:layout_weight="1"
-            />
+            android:layout_weight="1" />
 
 
     </LinearLayout>

--- a/mediacontroller/src/main/res/values/testing_strings.xml
+++ b/mediacontroller/src/main/res/values/testing_strings.xml
@@ -200,4 +200,8 @@
     <!-- For example, the command `adb shell input text hello%sworld` will add the string "hello world" to the input field (%s indicates a space) -->
     <string name="tv_text_input">%s\nSelect this test to open the query input field. To input text via adb, enter `adb shell input text [query]`.</string>
     <string name="tv_text_input_with_query">%s\nSelect this test to open the query input field. To input text via adb, enter `adb shell input text [query]`.\n\nEntered query: [%s]</string>
+    <string name="configure_button">Configure</string>
+    <string name="done_configure_button">Done</string>
+    <string name="reset_button_text">Reset</string>
+    <string name="query_hint">Query</string>
 </resources>

--- a/mediacontroller/src/main/res/values/testing_strings.xml
+++ b/mediacontroller/src/main/res/values/testing_strings.xml
@@ -52,6 +52,10 @@
     <string name= "test_suite_error_invalid_iter">Invalid iteration number, must be between (1..100).</string>
     <string name= "test_suite_already_running">Please wait for current test suite to finish.</string>
     <string name="close_results_button">Close</string>
+    <string name="configure_button">Configure</string>
+    <string name="done_configure_button">Done</string>
+    <string name="reset_button_text">Reset</string>
+    <string name="query_hint">Query</string>
 
 
     <!-- Logs Toggle -->
@@ -200,8 +204,4 @@
     <!-- For example, the command `adb shell input text hello%sworld` will add the string "hello world" to the input field (%s indicates a space) -->
     <string name="tv_text_input">%s\nSelect this test to open the query input field. To input text via adb, enter `adb shell input text [query]`.</string>
     <string name="tv_text_input_with_query">%s\nSelect this test to open the query input field. To input text via adb, enter `adb shell input text [query]`.\n\nEntered query: [%s]</string>
-    <string name="configure_button">Configure</string>
-    <string name="done_configure_button">Done</string>
-    <string name="reset_button_text">Reset</string>
-    <string name="query_hint">Query</string>
 </resources>

--- a/mediacontroller/src/main/res/values/testing_strings.xml
+++ b/mediacontroller/src/main/res/values/testing_strings.xml
@@ -56,6 +56,7 @@
     <string name="done_configure_button">Done</string>
     <string name="reset_button_text">Reset</string>
     <string name="query_hint">Query</string>
+    <string name="run_suite_button">Run Suite</string>
 
 
     <!-- Logs Toggle -->


### PR DESCRIPTION
Adds the option to configure a specific query for a specific test in a test suite. For example it allows the user to provide a URI for the `play media from URI` test. Only tests that don't require configuration and ones that have the query configured will be run when the suite is run. 