### PR TITLE
Add a save button to the media controller tester app, 

### DIFF
--- a/mediacontroller/src/main/AndroidManifest.xml
+++ b/mediacontroller/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.android.mediacontroller">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
@@ -248,7 +248,7 @@ public class MediaAppControllerActivity extends AppCompatActivity {
         browseTreeList.setHasFixedSize(true);
         browseTreeList.setAdapter(mBrowseMediaItemsAdapter);
         mBrowseMediaItemsAdapter.init(findViewById(R.id.media_browse_tree_top),
-                findViewById(R.id.media_browse_tree_up));
+                findViewById(R.id.media_browse_tree_up), findViewById(R.id.media_browse_tree_save));
 
         final RecyclerView browseTreeListExtraSuggested = findViewById(R.id.media_items_list_extra_suggested);
         browseTreeListExtraSuggested.setLayoutManager(new LinearLayoutManager(this));
@@ -1206,7 +1206,7 @@ public class MediaAppControllerActivity extends AppCompatActivity {
          * Assigns click handlers to the buttons if provided for moving to the top of the tree or
          * for moving up one level in the tree.
          */
-        void init(View topButtonView, View upButtonView) {
+        void init(View topButtonView, View upButtonView, View saveButtonView) {
             if (topButtonView != null) {
                 topButtonView.setOnClickListener(v -> {
                     if (mNodes.size() > 1) {
@@ -1227,6 +1227,75 @@ public class MediaAppControllerActivity extends AppCompatActivity {
                         subscribe();
                     }
                 });
+            }
+	
+	    if (saveButtonView != null) {
+        	saveButtonView.setOnClickListener(v -> {
+              	    if (mNodes.isEmpty()) {
+                        Toast toast =
+                    Toast.makeText(
+                        getApplicationContext(), "List Empty, nothing saved! ", Toast.LENGTH_LONG);
+                toast.setMargin(50, 50);
+                toast.show();
+                return;
+              }
+              File root = android.os.Environment.getExternalStorageDirectory();
+              File dir = new File(root.getAbsolutePath() + "/Temp");
+              dir.mkdirs();
+              File file = new File(dir, "_BrowseTreeContent.txt");
+              if (file.exists()) {
+                file.delete();
+              }
+              try {
+                FileOutputStream f = new FileOutputStream(file);
+                PrintWriter pw = new PrintWriter(f);
+                // We print the file path at the beginning of the file so that we can use it
+                // to pull the file from android to local computer in case user have forgotten.
+                pw.println(file.toString());
+
+                for (MediaBrowserCompat.MediaItem item : mItems) {
+                  MediaDescriptionCompat descriptionCompat = item.getDescription();
+                  if (descriptionCompat != null) {
+                    String infoStr =
+                        "Title:" + descriptionCompat.getTitle() != null
+                            ? descriptionCompat.getTitle().toString()
+                            : "NAN";
+                    infoStr +=
+                        ",Subtitle:" + descriptionCompat.getSubtitle() != null
+                            ? descriptionCompat.getSubtitle().toString()
+                            : "NAN";
+                    infoStr +=
+                        ",MediaId:" + descriptionCompat.getMediaId() != null
+                            ? descriptionCompat.getMediaId().toString()
+                            : "NAN";
+                    infoStr +=
+                        ",Uri:" + descriptionCompat.getMediaUri() != null
+                            ? descriptionCompat.getMediaUri().toString()
+                            : "NAN";
+                    infoStr +=
+                        ",Description:" + descriptionCompat.getDescription() != null
+                            ? descriptionCompat.getDescription().toString()
+                            : "NAN";
+                    pw.println(infoStr);
+                  }
+                }
+
+                pw.flush();
+                pw.close();
+                f.close();
+                Toast toast =
+                    Toast.makeText(
+                        getApplicationContext(),
+                        "MediaItems saved to " + file.getAbsolutePath(),
+                        Toast.LENGTH_LONG);
+                toast.setMargin(50, 50);
+                toast.show();
+              } catch (FileNotFoundException e) {
+                e.printStackTrace();
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            });
             }
         }
 

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
@@ -33,6 +33,7 @@ import android.os.Bundle;
 import android.os.RemoteException;
 import android.support.v4.media.MediaBrowserCompat;
 import android.support.v4.media.MediaBrowserCompat.MediaItem;
+import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaControllerCompat;
@@ -73,6 +74,11 @@ import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.tabs.TabLayout;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -255,13 +261,13 @@ public class MediaAppControllerActivity extends AppCompatActivity {
         browseTreeListExtraSuggested.setHasFixedSize(true);
         browseTreeListExtraSuggested.setAdapter(mBrowseMediaItemsExtraSuggestedAdapter);
         mBrowseMediaItemsExtraSuggestedAdapter.init(findViewById(R.id.media_browse_tree_top_extra_suggested),
-                findViewById(R.id.media_browse_tree_up_extra_suggested));
+                findViewById(R.id.media_browse_tree_up_extra_suggested), findViewById(R.id.media_browse_tree_save_extra_suggested));
 
         final RecyclerView searchItemsList = findViewById(R.id.search_items_list);
         searchItemsList.setLayoutManager(new LinearLayoutManager(this));
         searchItemsList.setHasFixedSize(true);
         searchItemsList.setAdapter(mSearchMediaItemsAdapter);
-        mSearchMediaItemsAdapter.init(null, null);
+        mSearchMediaItemsAdapter.init(null, null, null);
 
         findViewById(R.id.search_button).setOnClickListener(v -> {
             CharSequence queryText = ((TextView) findViewById(R.id.search_query)).getText();

--- a/mediacontroller/src/main/res/layout/media_browse_tree.xml
+++ b/mediacontroller/src/main/res/layout/media_browse_tree.xml
@@ -44,6 +44,12 @@
             android:layout_height="wrap_content"
             android:text="@string/media_browse_tree_up" />
 
+	<Button
+            android:id="@+id/media_browse_tree_save"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/media_browse_tree_save" />
+
     </LinearLayout>
 
     <TextView

--- a/mediacontroller/src/main/res/layout/media_browse_tree_extra_suggested.xml
+++ b/mediacontroller/src/main/res/layout/media_browse_tree_extra_suggested.xml
@@ -44,6 +44,12 @@
             android:layout_height="wrap_content"
             android:text="@string/media_browse_tree_up" />
 
+        <Button
+            android:id="@+id/media_browse_tree_save_extra_suggested"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/media_browse_tree_up" />
+
     </LinearLayout>
 
     <TextView

--- a/mediacontroller/src/main/res/values/strings.xml
+++ b/mediacontroller/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
 
     <string name="media_browse_tree_top">Top</string>
     <string name="media_browse_tree_up">Up</string>
+    <string name="media_browse_tree_save">Save to file</string>
     <string name="media_browse_tree_header">App-provided MediaItems</string>
     <string name="media_browse_tree_extra_suggested_header">App-provided MediaItems Extra Suggested Flag</string>
     <string name="media_no_browser">No Browser</string>


### PR DESCRIPTION
Hi, 

This pr is to create a save button in the media browse tree view, so that we can save the content of the browse tree to device, and later on transfer to computer for more analysis. 
This change is in response to the request for assistant features on radio station names. To better support radio station names, we would need to analyze on the contents of the radio browser, and MCT would be a good way for us to communicate with partners to ask them to help us on getting this data. 

Best, 