### PR TITLE
Create a foreground service and migrate testing logic into service

### DIFF
--- a/mediacontroller/src/main/AndroidManifest.xml
+++ b/mediacontroller/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.android.mediacontroller">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
@@ -96,5 +98,10 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+
+        <service
+            android:name=".MediaAppTestService"
+            android:enabled="true"
+            android:exported="true" />
     </application>
 </manifest>

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppControllerActivity.java
@@ -482,8 +482,6 @@ public class MediaAppControllerActivity extends AppCompatActivity {
 
             // Ensure views are visible.
             mViewPager.setVisibility(View.VISIBLE);
-
-            Log.d(TAG, "MediaControllerCompat created");
         } catch (RemoteException remoteException) {
             Log.e(TAG, "Failed to create MediaController from session token", remoteException);
             showToastAndFinish(getString(R.string.media_controller_failed_msg));

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestService.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestService.kt
@@ -1,0 +1,844 @@
+package com.example.android.mediacontroller
+
+import android.app.*
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.*
+import android.support.v4.media.MediaBrowserCompat
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaControllerCompat
+import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import android.util.Log
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import kotlinx.android.synthetic.main.media_test_suites.*
+import kotlinx.android.synthetic.main.media_tests.*
+
+// TODO: Remove all context-related code outside of this service
+class MediaAppTestService : Service() {
+
+    private val TAG = "MediaAppTestService"
+    private val NOTIFICATION_CHANNEL_ID = "MediaAppTestService"
+    private val NOTIFICATION_ID = 1001
+
+    private var mediaAppDetails: MediaAppDetails? = null
+    private var mediaController: MediaControllerCompat? = null
+    private var mediaBrowser: MediaBrowserCompat? = null
+
+    private var printLogsFormatted: Boolean = true
+    private var callback: ICallback? = null
+    private var testList: List<TestOptionDetails>? = null
+    private var testSuites: List<MediaAppTestSuite>? = null
+    private var context: Context? = null
+
+    private val binder = TestServiceBinder()
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // To make sure the service keeps running
+        startForeground(NOTIFICATION_ID, createNotification())
+
+        Log.d(TAG, "onStartCommand")
+        Log.d(TAG, "intent: $intent")
+        if (intent != null) {
+            Log.d(TAG, "intent string: " + intent.getStringExtra("string"))
+            Log.d(TAG, "intent string: " + intent.getLongExtra("long", 0))
+        }
+
+
+        showToast("done!")
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return binder
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        startForeground(NOTIFICATION_ID, createNotification())
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        mediaController?.run {
+            unregisterCallback(controllerCallback)
+            currentTest?.endTest()
+        }
+        mediaController = null
+
+        mediaBrowser?.let {
+            if (it.isConnected) {
+                it.disconnect()
+            }
+        }
+        mediaBrowser = null
+
+        stopForeground(true)
+    }
+
+    inner class TestServiceBinder : Binder() {
+        fun getService() : MediaAppTestService {
+            return this@MediaAppTestService
+        }
+    }
+
+    fun getMediaAppDetails() = mediaAppDetails
+
+    fun setupMedia(mediaAppDetails: MediaAppDetails) {
+        when {
+            mediaAppDetails.componentName != null -> {
+                mediaBrowser = MediaBrowserCompat(this, mediaAppDetails.componentName,
+                        object : MediaBrowserCompat.ConnectionCallback() {
+                            override fun onConnected() {
+                                callback?.let {
+                                    it.onConnected()
+                                }
+                                setupMediaController(true)
+                            }
+
+                            override fun onConnectionSuspended() {
+                                callback?.let {
+                                    it.onConnectionSuspended(mediaAppDetails.appName)
+                                }
+                            }
+
+                            override fun onConnectionFailed() {
+                                callback?.let {
+                                    it.onConnectionFailed(mediaAppDetails.appName,
+                                            mediaAppDetails.componentName)
+                                }
+                            }
+                        }, null).apply { connect() }
+            }
+            mediaAppDetails.sessionToken != null -> setupMediaController(false)
+        }
+    }
+
+    fun setupMediaController(useTokenFromBrowser: Boolean) {
+        try {
+            val token: MediaSessionCompat.Token
+            // setupMediaController() is only called either immediately after the mediaBrowser is
+            // connected or if mediaAppDetails contains a sessionToken.
+            if (useTokenFromBrowser) {
+                val browser = mediaBrowser
+                if (browser != null) {
+                    token = browser.sessionToken
+                } else {
+                    if (callback != null) {
+                        callback!!.onSetupMediaControllerError(getString(
+                                R.string.setup_media_controller_error_hint,
+                                "MediaBrowser"
+                        ))
+                    } else {
+                        Log.e(TAG, getString(
+                                R.string.setup_media_controller_error_msg,
+                                "MediaBrowser"
+                        ))
+                    }
+                    return
+                }
+            } else {
+                val appDetails = mediaAppDetails
+                if (appDetails != null) {
+                    token = appDetails.sessionToken
+                } else {
+                    if (callback != null) {
+                        callback!!.onSetupMediaControllerError(getString(
+                                R.string.setup_media_controller_error_hint,
+                                "MediaAppDetails"
+                        ))
+                    } else {
+                        Log.e(TAG, getString(
+                                R.string.setup_media_controller_error_msg,
+                                "MediaAppDetails"
+                        ))
+                    }
+                    return
+                }
+            }
+
+            mediaController = MediaControllerCompat(this, token).also {
+                it.registerCallback(controllerCallback)
+
+                // Force update on connect
+                logCurrentController(it)
+            }
+
+            // Setup tests once media controller is connected
+            setupTests()
+        } catch (remoteException: RemoteException) {
+            showToast(getString(R.string.media_controller_failed_msg))
+        }
+    }
+
+    fun setPrintLogsFormatted(printLogsFormatted: Boolean) {
+        this.printLogsFormatted = printLogsFormatted
+    }
+
+    fun getPrintLogsFormatted(): Boolean = printLogsFormatted
+
+    fun logCurrentController(controller: MediaControllerCompat? = mediaController) {
+        if (controller == null) {
+            showToast("Null MediaController")
+            return
+        }
+
+        controllerCallback.run {
+            onPlaybackStateChanged(controller.playbackState)
+            onMetadataChanged(controller.metadata)
+            onRepeatModeChanged(controller.repeatMode)
+            onShuffleModeChanged(controller.shuffleMode)
+            onQueueTitleChanged(controller.queueTitle)
+            onQueueChanged(controller.queue)
+        }
+    }
+
+    private fun showToast(message: String) {
+        Log.d(TAG, "showToast: $applicationContext")
+        Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
+    }
+
+    fun isSuiteRunning(): Boolean {
+        testSuites?.let {
+            for (test in it) {
+                if (test.suiteIsRunning()) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    fun handleIntent(intent: Intent) {
+        if (intent == null) {
+            return
+        }
+
+        mediaBrowser?.let {
+            if (it.isConnected) {
+                it.disconnect()
+            }
+        }
+
+        val data = intent.data
+        val appPackageName: String? = when {
+            data != null -> data.host
+            intent.hasExtra(PACKAGE_NAME_EXTRA) -> intent.getStringExtra(PACKAGE_NAME_EXTRA)
+            else -> null
+        }
+
+        // Get new MediaAppDetails object from intent extras if present (otherwise keep current
+        // MediaAppDetails object)
+        val extras = intent.extras
+        val hasAppDetailsExtra = extras?.containsKey(APP_DETAILS_EXTRA) ?: false
+        if (hasAppDetailsExtra) {
+            mediaAppDetails = extras.getParcelable(APP_DETAILS_EXTRA)
+        }
+
+        // Update MediaAppDetails object if needed (the if clause after the || handles the case when
+        // the object has already been set up before, but the Intent contains details for a
+        // different app)
+        val appDetails = mediaAppDetails
+        if ((appDetails == null && appPackageName != null)
+                || (appDetails != null && appPackageName != appDetails.packageName)) {
+            val serviceInfo = MediaAppDetails.findServiceInfo(appPackageName, packageManager)
+            if (serviceInfo != null) {
+                mediaAppDetails = MediaAppDetails(serviceInfo, packageManager, resources)
+            }
+        } else {
+            Toast.makeText(
+                    applicationContext,
+                    getString(R.string.media_app_details_update_failed),
+                    Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    private fun setupTests() {
+        // setupTests() should only be called after the mediaController is connected, so this
+        // should never enter the if block
+        val controller = mediaController
+        if (controller == null) {
+            Log.e(TAG, getString(R.string.setup_tests_error_msg))
+            showToast(getString(R.string.setup_tests_error_msg))
+            return
+        }
+
+        /**
+         * Tests the play() transport control. The test can start in any state, might enter a
+         * transition state, but must eventually end in STATE_PLAYING. The test will fail for
+         * any terminal state other than the starting state and STATE_PLAYING. The test
+         * will also fail if the metadata changes unless the test began with null metadata.
+         */
+        val playTest = TestOptionDetails(
+                0,
+                getString(R.string.play_test_title),
+                getString(R.string.play_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId -> runPlayTest(testId, controller, callback) }
+
+        /**
+         * Tests the playFromSearch() transport control. The test can start in any state, might
+         * enter a transition state, but must eventually end in STATE_PLAYING with playback
+         * position at 0. The test will fail for any terminal state other than the starting state
+         * and STATE_PLAYING. This test does not perform any metadata checks.
+         */
+        val playFromSearch = TestOptionDetails(
+                1,
+                getString(R.string.play_search_test_title),
+                getString(R.string.play_search_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { query, callback, testId ->
+            runPlayFromSearchTest(
+                    testId, query, controller, callback)
+        }
+
+        /**
+         * Tests the playFromMediaId() transport control. The test can start in any state, might
+         * enter a transition state, but must eventually end in STATE_PLAYING with playback
+         * position at 0. The test will fail for any terminal state other than the starting state
+         * and STATE_PLAYING. The test will also fail if query is empty/null. This test does not
+         * perform any metadata checks.
+         */
+        val playFromMediaId = TestOptionDetails(
+                2,
+                getString(R.string.play_media_id_test_title),
+                getString(R.string.play_media_id_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                true
+        ) { query, callback, testId ->
+            runPlayFromMediaIdTest(
+                    testId, query, controller, callback)
+        }
+
+        /**
+         * Tests the playFromUri() transport control. The test can start in any state, might
+         * enter a transition state, but must eventually end in STATE_PLAYING with playback
+         * position at 0. The test will fail for any terminal state other than the starting state
+         * and STATE_PLAYING. The test will also fail if query is empty/null. This test does not
+         * perform any metadata checks.
+         */
+        val playFromUri = TestOptionDetails(
+                3,
+                getString(R.string.play_uri_test_title),
+                getString(R.string.play_uri_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                true
+        ) { query, callback, testId ->
+            runPlayFromUriTest(
+                    testId, query, controller, callback)
+        }
+
+        /**
+         * Tests the pause() transport control. The test can start in any state, but must end in
+         * STATE_PAUSED (but STATE_STOPPED is also okay if that is the state the test started with).
+         * The test will fail for any terminal state other than the starting state, STATE_PAUSED,
+         * and STATE_STOPPED. The test will also fail if the metadata changes unless the test began
+         * with null metadata.
+         */
+        val pauseTest = TestOptionDetails(
+                4,
+                getString(R.string.pause_test_title),
+                getString(R.string.pause_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId -> runPauseTest(testId, controller, callback) }
+
+        /**
+         * Tests the stop() transport control. The test can start in any state, but must end in
+         * STATE_STOPPED or STATE_NONE. The test will fail for any terminal state other than the
+         * starting state, STATE_STOPPED, and STATE_NONE. The test will also fail if the metadata
+         * changes to a non-null media item different from the original media item.
+         */
+        val stopTest = TestOptionDetails(
+                5,
+                getString(R.string.stop_test_title),
+                getString(R.string.stop_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId -> runStopTest(testId, controller, callback) }
+
+        /**
+         * Tests the skipToNext() transport control. The test can start in any state, might
+         * enter a transition state, but must eventually end in STATE_PLAYING with the playback
+         * position at 0 if a new media item is started or in the starting state if the media item
+         * doesn't change. The test will fail for any terminal state other than the starting state
+         * and STATE_PLAYING. The metadata must change, but might just "change" to be the same as
+         * the original metadata (e.g. if the next media item is the same as the current one); the
+         * test will not pass if the metadata doesn't get updated at some point.
+         */
+        val skipToNextTest = TestOptionDetails(
+                6,
+                getString(R.string.skip_next_test_title),
+                getString(R.string.skip_next_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runSkipToNextTest(
+                    testId, controller, callback)
+        }
+
+        /**
+         * Tests the skipToPrevious() transport control. The test can start in any state, might
+         * enter a transition state, but must eventually end in STATE_PLAYING with the playback
+         * position at 0 if a new media item is started or in the starting state if the media item
+         * doesn't change. The test will fail for any terminal state other than the starting state
+         * and STATE_PLAYING. The metadata must change, but might just "change" to be the same as
+         * the original metadata (e.g. if the previous media item is the same as the current one);
+         * the test will not pass if the metadata doesn't get updated at some point.
+         */
+        val skipToPrevTest = TestOptionDetails(
+                7,
+                getString(R.string.skip_prev_test_title),
+                getString(R.string.skip_prev_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runSkipToPrevTest(
+                    testId, controller, callback)
+        }
+
+        /**
+         * Tests the skipToQueueItem() transport control. The test can start in any state, might
+         * enter a transition state, but must eventually end in STATE_PLAYING with the playback
+         * position at 0 if a new media item is started or in the starting state if the media item
+         * doesn't change. The test will fail for any terminal state other than the starting state
+         * and STATE_PLAYING. The metadata must change, but might just "change" to be the same as
+         * the original metadata (e.g. if the next media item is the same as the current one); the
+         * test will not pass if the metadata doesn't get updated at some point.
+         */
+        val skipToItemTest = TestOptionDetails(
+                8,
+                getString(R.string.skip_item_test_title),
+                getString(R.string.skip_item_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                true
+        ) { query, callback, testId ->
+            runSkipToItemTest(
+                    testId, query, controller, callback)
+        }
+
+        /**
+         * Tests the seekTo() transport control. The test can start in any state, might enter a
+         * transition state, but must eventually end in a terminal state with playback position at
+         * the requested timestamp. While not required, it is expected that the test will end in
+         * the same state as it started. Metadata might change for this test if the requested
+         * timestamp is outside the bounds of the current media item. The query should either be
+         * a position in seconds or a change in position (number of seconds prepended by '+' to go
+         * forward or '-' to go backwards). The test will fail if the query can't be parsed to a
+         * Long.
+         */
+        val seekToTest = TestOptionDetails(
+                9,
+                getString(R.string.seek_test_title),
+                getString(R.string.seek_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                true
+        ) { query, callback, testId ->
+            runSeekToTest(
+                    testId, query, controller, callback)
+        }
+
+        /**
+         * Automotive and Auto shared tests
+         */
+        val browseTreeDepthTest = TestOptionDetails(
+                10,
+                getString(R.string.browse_tree_depth_test_title),
+                getString(R.string.browse_tree_depth_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                runBrowseTreeDepthTest(
+                        testId, controller, mediaBrowser, callback)
+            } else {
+                Toast.makeText(
+                        applicationContext,
+                        "This test requires minSDK 24",
+                        Toast.LENGTH_SHORT)
+                        .show()
+            }
+        }
+
+        val mediaArtworkTest = TestOptionDetails(
+                11,
+                getString(R.string.media_artwork_test_title),
+                getString(R.string.media_artwork_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                runMediaArtworkTest(
+                        testId, controller, mediaBrowser, callback)
+            } else {
+                Toast.makeText(
+                        applicationContext,
+                        "This test requires minSDK 24",
+                        Toast.LENGTH_SHORT)
+                        .show()
+            }
+        }
+
+        val contentStyleTest = TestOptionDetails(
+                12,
+                getString(R.string.content_style_test_title),
+                getString(R.string.content_style_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runContentStyleTest(
+                    testId, controller, mediaBrowser, callback)
+        }
+
+        val customActionIconTypeTest = TestOptionDetails(
+                13,
+                getString(R.string.custom_actions_icon_test_title),
+                getString(R.string.custom_actions_icon_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runCustomActionIconTypeTest(
+                    testId, applicationContext, controller, mediaAppDetails, callback)
+        }
+
+        val supportsSearchTest = TestOptionDetails(
+                14,
+                getString(R.string.search_supported_test_title),
+                getString(R.string.search_supported_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runSearchTest(
+                    testId, controller, mediaBrowser, callback)
+        }
+
+        val initialPlaybackStateTest = TestOptionDetails(
+                15,
+                getString(R.string.playback_state_test_title),
+                getString(R.string.playback_state_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runInitialPlaybackStateTest(
+                    testId, controller, callback)
+        }
+
+        /**
+         * Automotive specific tests
+         */
+        val browseTreeStructureTest = TestOptionDetails(
+                16,
+                getString(R.string.browse_tree_structure_test_title),
+                getString(R.string.browse_tree_structure_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                runBrowseTreeStructureTest(
+                        testId, controller, mediaBrowser, callback)
+            } else {
+                Toast.makeText(
+                        applicationContext,
+                        getString(R.string.test_error_minsdk),
+                        Toast.LENGTH_SHORT)
+                        .show()
+            }
+        }
+
+        val preferenceTest = TestOptionDetails(
+                17,
+                getString(R.string.preference_activity_test_title),
+                getString(R.string.preference_activity_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runPreferenceTest(
+                    testId, controller, mediaAppDetails, packageManager, callback)
+        }
+
+        val errorResolutionDataTest = TestOptionDetails(
+                18,
+                getString(R.string.error_resolution_test_title),
+                getString(R.string.error_resolution_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runErrorResolutionDataTest(
+                    testId, controller, callback)
+        }
+
+        val launcherTest = TestOptionDetails(
+                19,
+                getString(R.string.launcher_intent_test_title),
+                getString(R.string.launcher_intent_test_desc),
+                TestResult.NONE,
+                Test.NO_LOGS,
+                false
+        ) { _, callback, testId ->
+            runLauncherTest(
+                    testId, controller, mediaAppDetails, packageManager, callback)
+        }
+
+        val basicTests = arrayOf(
+                playFromSearch,
+                playFromMediaId,
+                playFromUri,
+                playTest,
+                pauseTest,
+                stopTest,
+                skipToNextTest,
+                skipToPrevTest,
+                skipToItemTest,
+                seekToTest
+        )
+
+        val commonTests = arrayOf(
+                browseTreeDepthTest,
+                mediaArtworkTest,
+                //TODO FIX contentStyleTest,
+                customActionIconTypeTest,
+                //TODO: FIX supportsSearchTest,
+                initialPlaybackStateTest
+        )
+
+        val automotiveTests = arrayOf(
+                browseTreeStructureTest,
+                preferenceTest,
+                errorResolutionDataTest,
+                launcherTest
+        )
+
+        var testList = basicTests
+        var testSuites: ArrayList<MediaAppTestSuite> = ArrayList()
+
+        val basicTestSuite = MediaAppTestSuite("Basic Tests", "Basic media tests.", basicTests)
+        testSuites.add(basicTestSuite)
+        if (mediaAppDetails?.supportsAuto == true || mediaAppDetails?.supportsAutomotive == true) {
+            testList += commonTests
+            val autoTestSuite = MediaAppTestSuite("Auto Tests",
+                    "Includes support for android auto tests.", testList)
+            testSuites.add(autoTestSuite)
+        }
+        if (mediaAppDetails?.supportsAutomotive == true) {
+            testList += automotiveTests
+            val automotiveTestSuite = MediaAppTestSuite("Automotive Tests",
+                    "Includes support for Android automotive tests.", testList)
+            testSuites.add(automotiveTestSuite)
+        }
+        this.testList = testList.asList()
+        this.testSuites = testSuites
+
+        callback?.let {
+            it.onTestsCreated(testList.asList(), testSuites)
+        }
+    }
+
+
+    /**
+     * This callback will log any changes in the playback state or metadata of the mediacontroller
+     */
+    private var controllerCallback: MediaControllerCompat.Callback =
+            object : MediaControllerCompat.Callback() {
+                override fun onPlaybackStateChanged(state: PlaybackStateCompat?) {
+                    val s = formatPlaybackState(state)
+                    if (printLogsFormatted) {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_formatted,
+                                getString(R.string.tests_info_state),
+                                s
+                        ))
+                    } else {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_parsable,
+                                getString(R.string.tests_info_state),
+                                formatPlaybackStateParsable(state)
+                        ))
+                    }
+                    callback?.let {
+                        it.onControllerPlaybackStateChanged(s)
+                    }
+                }
+
+                override fun onMetadataChanged(metadata: MediaMetadataCompat?) {
+                    val s = formatMetadata(metadata)
+                    if (printLogsFormatted) {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_formatted,
+                                getString(R.string.tests_info_metadata),
+                                s
+                        ))
+                    } else {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_parsable,
+                                getString(R.string.tests_info_metadata),
+                                formatMetadataParsable(metadata)
+                        ))
+                    }
+                    callback?.let {
+                        it.onControllerMetadataChanged(s)
+                    }
+                }
+
+                override fun onRepeatModeChanged(repeatMode: Int) {
+                    val s = repeatModeToName(repeatMode)
+                    if (printLogsFormatted) {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_formatted,
+                                getString(R.string.tests_info_repeat),
+                                s
+                        ))
+                    } else {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_parsable,
+                                getString(R.string.tests_info_repeat),
+                                repeatMode.toString()
+                        ))
+                    }
+                    callback?.let {
+                        it.onControllerRepeatModeChanged(s)
+                    }
+                }
+
+                override fun onShuffleModeChanged(shuffleMode: Int) {
+                    val s = shuffleModeToName(shuffleMode)
+                    if (printLogsFormatted) {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_formatted,
+                                getString(R.string.tests_info_shuffle),
+                                s
+                        ))
+                    } else {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_parsable,
+                                getString(R.string.tests_info_shuffle),
+                                shuffleMode.toString()
+                        ))
+                    }
+                    callback?.let {
+                        it.onControllerShuffleModeChanged(s)
+                    }
+                }
+
+                override fun onQueueTitleChanged(title: CharSequence?) {
+                    if (printLogsFormatted) {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_formatted,
+                                getString(R.string.tests_info_queue_title),
+                                title
+                        ))
+                    } else {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_parsable,
+                                getString(R.string.tests_info_queue_title),
+                                title
+                        ))
+                    }
+                    callback?.let {
+                        it.onControllerQueueTitleChanged(title)
+                    }
+                }
+
+                override fun onQueueChanged(queue: MutableList<MediaSessionCompat.QueueItem>?) {
+                    if (printLogsFormatted) {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_formatted,
+                                getString(R.string.tests_info_queue),
+                                queueToString(queue)
+                        ))
+                    } else {
+                        Log.i(TAG, getString(
+                                R.string.logs_controller_info_parsable,
+                                getString(R.string.tests_info_queue),
+                                queueToStringParsable(queue)
+                        ))
+                    }
+                    callback?.let {
+                        it.onControllerQueueChanged(queue)
+                    }
+                }
+            }
+
+    /**
+     * Create the notification to make sure we run in the foreground
+     * Note that this notification does NOT actually display on Android TV
+     */
+    private fun createNotification(): Notification {
+        // From API 26, the NotificationManager requires the use of notification channels.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            // Channel must be created
+            if (notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID) == null) {
+                val serviceChannel = NotificationChannel(
+                        NOTIFICATION_CHANNEL_ID,
+                        getString(R.string.app_name),
+                        NotificationManager.IMPORTANCE_DEFAULT
+                )
+                notificationManager.createNotificationChannel(serviceChannel)
+            }
+        }
+
+        val notificationIntent = Intent(applicationContext, MediaAppTestingActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(applicationContext, 0, notificationIntent, 0)
+
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(getText(R.string.app_name))
+                .setContentText(getText(R.string.notification_message))
+                .setSmallIcon(R.drawable.ic_android)
+                .setContentIntent(pendingIntent)
+                .build()
+    }
+
+    fun registerCallback(callback: ICallback) {
+        this.callback = callback
+    }
+
+    // declare callback function
+    interface ICallback {
+        fun onConnected()
+        fun onConnectionSuspended(appName: String)
+        fun onConnectionFailed(appName: String, componentName: ComponentName)
+        fun onSetupMediaControllerError(message: String)
+        fun onTestsCreated(testList: List<TestOptionDetails>, testSuites: List<MediaAppTestSuite>)
+        fun onControllerPlaybackStateChanged(playbackState: String)
+        fun onControllerMetadataChanged(metadata: String)
+        fun onControllerRepeatModeChanged(repeatMode: String)
+        fun onControllerShuffleModeChanged(shuffleMode: String)
+        fun onControllerQueueTitleChanged(title: CharSequence?)
+        fun onControllerQueueChanged(queue: MutableList<MediaSessionCompat.QueueItem>?)
+    }
+
+    companion object {
+        // Key names for external extras.
+        private const val PACKAGE_NAME_EXTRA = "com.example.android.mediacontroller.PACKAGE_NAME"
+
+        // Key name for Intent extras.
+        private const val APP_DETAILS_EXTRA =
+                "com.example.android.mediacontroller.APP_DETAILS_EXTRA"
+    }
+}

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestSuite.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestSuite.kt
@@ -15,40 +15,15 @@
  */
 package com.example.android.mediacontroller
 
-import android.animation.ArgbEvaluator
-import android.app.Dialog
-import android.content.Context
-import android.content.SharedPreferences
-import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import android.view.Gravity
-import android.view.View
-import android.view.ViewGroup
-import android.view.LayoutInflater
-import android.view.Window
-import android.widget.LinearLayout
-import android.widget.TextView
-import android.widget.ProgressBar
-import android.widget.Button
-import android.widget.ScrollView
-import androidx.cardview.widget.CardView
-import androidx.core.content.ContextCompat
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.media_test_option.view.card_header
-import kotlinx.android.synthetic.main.media_test_option.view.card_text
-import kotlinx.android.synthetic.main.media_test_suite_result.view.tests_passing
-import kotlinx.android.synthetic.main.media_test_suite_result.view.tests_passing_header
-import kotlinx.android.synthetic.main.media_test_suite_result.view.total_tests
 
 import java.util.concurrent.Semaphore
 import kotlin.concurrent.thread
 
-
 class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: String, private val testList:
-    Array<TestOptionDetails>, private val testSuiteResultsLayout: RecyclerView, val context: Context) {
+    Array<TestOptionDetails>) {
 
     private val TAG = "MediaAppTestSuite"
 
@@ -56,21 +31,6 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
      * Sleep time after a single test was run. Assures that all steps are flushed out.
      */
     private val SLEEP_TIME = 1000L
-
-    /**
-     * The color that is associated with passing tests.
-     */
-    private val PASSING_COLOR = ContextCompat.getColor(context, R.color.test_result_pass)
-
-    /**
-     * The color that is associated with failing tests.
-     */
-    private val FAILING_COLOR = ContextCompat.getColor(context, R.color.test_result_fail)
-
-    /**
-     * Adapter for displaying individual tests results.
-     */
-    private var resultsAdapter = ResultsAdapter(this.testList)
 
     /**
      * Semaphore to prevent two tests from being run at the same time and interfering with each other.
@@ -98,16 +58,6 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
     private var suiteRunning = false
 
     /**
-     * Object that is used to generate colors for partly passing tests.
-     */
-    private var argbEvaluator = ArgbEvaluator()
-
-    /**
-     * Used to retrieve test configurations.
-     */
-    private val sharedPreferences: SharedPreferences
-
-    /**
      * Thread to handle all of the test suite operations.
      */
     private lateinit var suiteThread: Thread
@@ -118,7 +68,6 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
             positionToIDMap[i] = testList[i].id
             iDToResultsMap[testList[i].id] = TestCaseResults()
         }
-        sharedPreferences = context.getSharedPreferences(MediaAppTestingActivity.SHARED_PREF_KEY_SUITE_CONFIG, Context.MODE_PRIVATE)
     }
 
     /**
@@ -142,40 +91,20 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
     }
 
     /**
-     * Runs a single test suite a specified number of iterations.
-     *
-     * @param numIter - The number of iterations to run the test suite.
+     * Gets all of the tests in the test suite.
      */
-    fun runSuite(numIter: Int) {
-        resetTests()
-        var progressBar :ProgressBar
-        val dialog = Dialog(context)
-        dialog.apply {
-            setCancelable(false)
-            requestWindowFeature(Window.FEATURE_NO_TITLE)
-            setContentView(R.layout.run_suite_iter_dialog)
-            progressBar = findViewById<ProgressBar>(R.id.suite_iter_progress_bar).apply {
-                max = numIter * testList.size
-                progress = -1
-            }
-            findViewById<Button>(R.id.quit_suite_iter_button).setOnClickListener{
-                interrupt()
-                dismiss()
-            }
-            window.setLayout(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
-        }.show()
-        runSuiteImpl(dialog, progressBar, numIter)
+    fun getTestList(): Array<TestOptionDetails> {
+        return testList
     }
 
     /**
      * Runs the full test suite a fixed number of times.
      *
-     * @param dialog - The loading dialog to close when the suite is finished running.
-     * @param progressBar - The progress bar to update with the suites status.
      * @param numIter - The number of times to run the test suite.
      */
-    private fun runSuiteImpl(dialog: Dialog, progressBar: ProgressBar, numIter: Int){
-        resultsAdapter = ResultsAdapter(testList)
+    fun runSuite(numIter: Int, queries: HashMap<String, String>, onStartTest: () -> Unit,
+                 onFinishTestSuite: (idToResultMap: HashMap<Int, TestCaseResults>) -> Unit) {
+        resetTests()
         suiteRunning = true
         suiteThread = thread(start = true) {
             Looper.prepare()
@@ -183,17 +112,16 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
                 for(i in 0 until numIter) {
                     for (test in testList) {
                         resetSingleResults()
-                        progressBar.incrementProgressBy(1)
+                        onStartTest()
 
                         // Flush out any residual media control commands from previous test
                         Thread.sleep(SLEEP_TIME)
 
                         // In the event that a query is not specified, don't run the test.
-                        var query = sharedPreferences.getString(test.name, MediaAppTestingActivity.NO_CONFIG)
+                        var query = MediaAppTestingActivity.NO_CONFIG
+                        query = queries[test.name] ?: MediaAppTestingActivity.NO_CONFIG
                         if (test.queryRequired && query == MediaAppTestingActivity.NO_CONFIG) {
                             test.testResult = TestResult.CONFIG_REQUIRED
-                            val index = positionToIDMap[test.id]
-                            mHandler.post { resultsAdapter.notifyItemChanged(index!!) }
                             continue
                         }
 
@@ -209,10 +137,7 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
             }
             suiteRunning = false
             mHandler.post {
-                Log.i(TAG, "Starting to display results")
-                displayResults()
-                Log.i(TAG, "Finished displaying results")
-                dialog.dismiss()
+                onFinishTestSuite(iDToResultsMap)
             }
         }
     }
@@ -252,7 +177,7 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
     /**
      * Interrupts the test suite and resets its all of its results.
      */
-    private fun interrupt(){
+    fun interrupt(){
         if (!this::suiteThread.isInitialized){
             return
         }
@@ -279,20 +204,8 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
         for (test in testList) {
             iDToResultsMap[test.id] = TestCaseResults()
         }
-        resultsAdapter = ResultsAdapter(arrayOf<TestOptionDetails>())
-        testSuiteResultsLayout.removeAllViews()
-        displayResults()
     }
 
-
-    /**
-     * Displays the test suite results using a RecyclerView.
-     */
-    private fun displayResults() {
-        testSuiteResultsLayout.layoutManager = LinearLayoutManager(context)
-        testSuiteResultsLayout.setHasFixedSize(true)
-        testSuiteResultsLayout.adapter = resultsAdapter
-    }
 
     /**
      * Class to store all of a tests resulting info.
@@ -302,110 +215,5 @@ class MediaAppTestSuite(val testSuiteName: String, val testSuiteDescription: Str
         var numPassing = 0
         var passingLogs = arrayListOf<ArrayList<String>>()
         var failingLogs = arrayListOf<ArrayList<String>>()
-    }
-
-    /**
-     *  Adapter to display each test and the number of associated successes.
-     */
-    inner class ResultsAdapter(
-            private val tests: Array<TestOptionDetails>
-    ) : RecyclerView.Adapter<ResultsAdapter.ViewHolder>() {
-        inner class ViewHolder(val cardView: CardView) : RecyclerView.ViewHolder(cardView)
-
-        override fun onCreateViewHolder(
-                parent: ViewGroup,
-                viewType: Int
-        ): ResultsAdapter.ViewHolder {
-            val cardView = LayoutInflater.from(parent.context)
-                    .inflate(R.layout.media_test_suite_result, parent, false) as CardView
-            return ViewHolder(cardView)
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val testID = positionToIDMap[position]!!
-            val testCaseResults = iDToResultsMap[testID]!!
-            holder.cardView.card_header.text = tests[position].name
-            holder.cardView.card_text.text = tests[position].desc
-            holder.cardView.total_tests.text = testCaseResults.totalRuns.toString()
-            holder.cardView.tests_passing.text = testCaseResults.numPassing.toString()
-            if(testCaseResults.totalRuns == 0){
-                holder.cardView.setOnClickListener{}
-                holder.cardView.tests_passing_header.text = context.getString(R.string.test_suite_config_needed_header)
-                holder.cardView.setCardBackgroundColor(Color.GRAY)
-                return
-            }
-            val passPercentage = testCaseResults.numPassing.toFloat() / testCaseResults.totalRuns.toFloat()
-            holder.cardView.setCardBackgroundColor((argbEvaluator.evaluate(passPercentage, FAILING_COLOR, PASSING_COLOR )) as Int)
-            val onResultsClickedListener = OnResultsClickedListener(testID, tests[position].name, tests[position].desc, this@MediaAppTestSuite.context)
-            holder.cardView.setOnClickListener(onResultsClickedListener)
-        }
-
-        override fun getItemCount() = tests.size
-    }
-
-    /**
-     *  Listener for when a specific test result is clicked from the results adapter. Shows logs
-     * for runs associated with the specific tests.
-     */
-    inner class OnResultsClickedListener(private val testId: Int, private val name: String, private val description: String, val context: Context) : View.OnClickListener {
-
-        override fun onClick(p0: View?) {
-            var dialog = Dialog(context).apply {
-                requestWindowFeature(Window.FEATURE_NO_TITLE)
-                setContentView(R.layout.test_suite_results_dialog)
-                findViewById<TextView>(R.id.results_title).text = name
-                findViewById<TextView>(R.id.results_subtitle).text = description
-
-                // Add the passing text log section
-                if(iDToResultsMap[testId]!!.passingLogs.isNotEmpty()) {
-                    val passing_results_log = findViewById<LinearLayout>(R.id.passing_results_log)
-                    passing_results_log.removeAllViews()
-                    for (logsList in iDToResultsMap[testId]!!.passingLogs) {
-                        passing_results_log.addView(TextView(context).apply {
-                            text = resources.getString(R.string.test_iter_divider)
-                            setTextAppearance(context, R.style.SubHeader)
-                            gravity = Gravity.CENTER
-                            setTextColor(PASSING_COLOR)
-                        })
-                        for (line in logsList) {
-                            var logLine = TextView(context).apply {
-                                text = line
-
-                                setTextAppearance(context, R.style.SubText)
-                            }
-                            passing_results_log.addView(logLine)
-                        }
-                    }
-                } else {
-                    findViewById<TextView>(R.id.passing_logs_header).visibility = View.GONE
-                }
-
-                // Add the passing text log section
-                if(iDToResultsMap[testId]!!.failingLogs.isNotEmpty()) {
-                    val failing_results_log = findViewById<LinearLayout>(R.id.failing_results_log)
-                    failing_results_log.removeAllViews()
-                    for (logsList in iDToResultsMap[testId]!!.failingLogs) {
-                        failing_results_log.addView(TextView(context).apply {
-                            text = resources.getString(R.string.test_iter_divider)
-                            setTextAppearance(context, R.style.SubHeader)
-                            gravity = Gravity.CENTER
-                            setTextColor(FAILING_COLOR)
-                        })
-                        for (line in logsList) {
-                            var logLine = TextView(context).apply {
-                                text = line
-                                setTextAppearance(context, R.style.SubText)
-                            }
-                            failing_results_log.addView(logLine)
-                        }
-                    }
-                }
-                else {
-                    findViewById<TextView>(R.id.failing_logs_header).visibility = View.GONE
-                }
-                findViewById<ScrollView>(R.id.results_scroll_view).layoutParams.height = (MediaAppTestingActivity.getScreenHeightPx(context) / 2).toInt()
-                findViewById<Button>(R.id.close_results_button).setOnClickListener(View.OnClickListener { dismiss() })
-            }.show()
-        }
     }
 }

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/MediaAppTestingActivity.kt
@@ -15,37 +15,25 @@
  */
 package com.example.android.mediacontroller
 
+import android.animation.ArgbEvaluator
 import android.app.Activity
 import android.app.Dialog
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
-import android.os.Build
 import android.os.Bundle
-import android.os.RemoteException
-import android.support.v4.media.MediaBrowserCompat
-import android.support.v4.media.MediaMetadataCompat
-import android.support.v4.media.session.MediaControllerCompat
+import android.os.IBinder
 import android.support.v4.media.session.MediaSessionCompat
-import android.support.v4.media.session.PlaybackStateCompat
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.DisplayMetrics
 import android.util.Log
-import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuItem
-import android.view.View
-import android.view.ViewGroup
-import android.view.Window
-import android.view.WindowManager
-
-import android.widget.EditText
-import android.widget.LinearLayout
-import android.widget.TextView
-import android.widget.Toast
+import android.view.*
+import android.widget.*
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
@@ -83,13 +71,10 @@ import kotlinx.android.synthetic.main.media_test_option.view.configure_test_suit
 import kotlinx.android.synthetic.main.media_test_option.view.card_text
 import kotlinx.android.synthetic.main.media_test_option.view.card_header
 import kotlinx.android.synthetic.main.media_test_option.view.card_button
+import kotlinx.android.synthetic.main.media_test_suite_result.view.*
+import kotlinx.android.synthetic.main.media_test_suites.*
 
-import kotlinx.android.synthetic.main.media_test_suites.test_suite_options_list
-import kotlinx.android.synthetic.main.media_test_suites.test_suite_results_container
-import kotlinx.android.synthetic.main.media_test_suites.test_suite_num_iter
-import kotlinx.android.synthetic.main.media_tests.test_results_container
-import kotlinx.android.synthetic.main.media_tests.tests_query
-import kotlinx.android.synthetic.main.media_tests.test_options_list
+import kotlinx.android.synthetic.main.media_tests.*
 import kotlinx.android.synthetic.main.test_suite_configure_dialog.done_button
 import kotlinx.android.synthetic.main.test_suite_configure_dialog.reset_results_button
 import kotlinx.android.synthetic.main.test_suite_configure_dialog.title
@@ -98,11 +83,27 @@ import kotlinx.android.synthetic.main.test_suite_configure_dialog.test_to_config
 
 
 class MediaAppTestingActivity : AppCompatActivity() {
-    private var mediaAppDetails: MediaAppDetails? = null
-    private var mediaController: MediaControllerCompat? = null
-    private var mediaBrowser: MediaBrowserCompat? = null
+    private var mediaAppTestService: MediaAppTestService? = null
 
     private var printLogsFormatted: Boolean = true
+    private var isBinding = false
+    private var testSuites: List<MediaAppTestSuite> = ArrayList()
+    private var resultsAdapter: ResultsAdapter? = null
+
+    /**
+     * Map relating tests positioning in the adapter to the tests ID.
+     */
+    private var positionToIDMap = hashMapOf<Int, Int>()
+
+    /**
+     * Map relating the tests ID to the result struct.
+     */
+    private var iDToResultsMap = hashMapOf<Int, MediaAppTestSuite.TestCaseResults>()
+
+    /**
+     * Object that is used to generate colors for partly passing tests.
+     */
+    private var argbEvaluator = ArgbEvaluator()
 
     private lateinit var viewPager: ViewPager
     private lateinit var testsQuery: EditText
@@ -137,16 +138,6 @@ class MediaAppTestingActivity : AppCompatActivity() {
         shuffleModeText = shuffle_mode_text
         queueTitleText = queue_title_text
         queueText = queue_text
-
-        handleIntent(intent)
-
-        val appDetails = mediaAppDetails
-        if (appDetails != null) {
-            setupMedia()
-            setupToolbar(appDetails.appName, appDetails.icon)
-        } else {
-            viewPager.visibility = View.GONE
-        }
 
         // Set up page navigation
         val pages = arrayOf(media_controller_info_page, media_controller_test_page, media_controller_test_suite_page)
@@ -196,102 +187,149 @@ class MediaAppTestingActivity : AppCompatActivity() {
                 bottomNavigationView.menu.getItem(position).isChecked = true
             }
         })
+
+        val intent = Intent(this, MediaAppTestService::class.java)
+        bindService(intent, connectionResult, Context.BIND_AUTO_CREATE)
     }
 
-
     override fun onDestroy() {
-        mediaController?.run {
-            unregisterCallback(controllerCallback)
-            currentTest?.endTest()
-        }
-        mediaController = null
-
-        mediaBrowser?.let {
-            if (it.isConnected) {
-                it.disconnect()
-            }
-        }
-        mediaBrowser = null
-
         super.onDestroy()
+
+        if (isBinding) {
+            unbindService(connectionResult)
+            isBinding = false
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        val originalDetails = mediaAppDetails
 
-        handleIntent(intent)
+        mediaAppTestService?.let {
+            val originalDetails = it.getMediaAppDetails()
+            it.handleIntent(intent)
 
-        // Redo setup for mediaBrowser and mediaController if mediaAppDetails is updated
-        val appDetails = mediaAppDetails
-        if (appDetails != null && appDetails != originalDetails) {
-            setupMedia()
-            setupToolbar(appDetails.appName, appDetails.icon)
-        } else {
-            viewPager.visibility = View.GONE
-        }
-    }
-
-    /**
-     * This is the single point where the MediaBrowser and MediaController are setup. If there is
-     * previously a controller/browser, they are disconnected/unsubscribed.
-     */
-    private fun handleIntent(intent: Intent?) {
-        if (intent == null) {
-            return
-        }
-
-        mediaBrowser?.let {
-            if (it.isConnected) {
-                it.disconnect()
+            // Redo setup for mediaBrowser and mediaController if mediaAppDetails is updated
+            val mediaAppDetails = it.getMediaAppDetails()
+            if (mediaAppDetails != null && mediaAppDetails != originalDetails) {
+                if (mediaAppDetails.componentName != null || mediaAppDetails.sessionToken != null) {
+                    mediaAppTestService!!.setupMedia(mediaAppDetails)
+                } else {
+                    showError(getString(R.string.connection_failed_hint_setup, mediaAppDetails.appName))
+                }
+                setupToolbar(mediaAppDetails.appName, mediaAppDetails.icon)
+                viewPager.visibility = View.VISIBLE
+            } else {
+                viewPager.visibility = View.GONE
             }
         }
+    }
 
-        val data = intent.data
-        val appPackageName: String? = when {
-            data != null -> data.host
-            intent.hasExtra(PACKAGE_NAME_EXTRA) -> intent.getStringExtra(PACKAGE_NAME_EXTRA)
-            else -> null
+    private var connectionResult = object : ServiceConnection {
+        override fun onServiceDisconnected(name: ComponentName?) {
+            isBinding = false
         }
 
-        // Get new MediaAppDetails object from intent extras if present (otherwise keep current
-        // MediaAppDetails object)
-        val extras = intent.extras
-        val hasAppDetailsExtra = extras?.containsKey(APP_DETAILS_EXTRA) ?: false
-        if (hasAppDetailsExtra) {
-            mediaAppDetails = extras.getParcelable(APP_DETAILS_EXTRA)
-        }
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            isBinding = true
+            val binder = service as MediaAppTestService.TestServiceBinder
+            mediaAppTestService = binder.getService()
+            mediaAppTestService!!.registerCallback(callback)
+            mediaAppTestService!!.handleIntent(intent)
 
-        // Update MediaAppDetails object if needed (the if clause after the || handles the case when
-        // the object has already been set up before, but the Intent contains details for a
-        // different app)
-        val appDetails = mediaAppDetails
-        if ((appDetails == null && appPackageName != null)
-                || (appDetails != null && appPackageName != appDetails.packageName)) {
-            val serviceInfo = MediaAppDetails.findServiceInfo(appPackageName, packageManager)
-            if (serviceInfo != null) {
-                mediaAppDetails = MediaAppDetails(serviceInfo, packageManager, resources)
+            val mediaAppDetails = mediaAppTestService!!.getMediaAppDetails()
+            if (mediaAppDetails != null) {
+                when {
+                    mediaAppDetails.componentName != null || mediaAppDetails.sessionToken != null -> {
+                        mediaAppTestService!!.setupMedia(mediaAppDetails)
+                    }
+                    else -> showError(getString(R.string.connection_failed_hint_setup, mediaAppDetails.appName))
+                }
+                setupToolbar(mediaAppDetails.appName, mediaAppDetails.icon)
+                viewPager.visibility = View.VISIBLE
+            } else {
+                viewPager.visibility = View.GONE
             }
-        } else {
-            Toast.makeText(
-                    this,
-                    getString(R.string.media_app_details_update_failed),
-                    Toast.LENGTH_SHORT
-            ).show()
         }
     }
 
-    override fun onSaveInstanceState(out: Bundle) {
-        super.onSaveInstanceState(out)
+    private val callback = object : MediaAppTestService.ICallback {
+        override fun onConnected() {
+            connectionErrorText.visibility = View.GONE
+        }
 
-        out.putParcelable(STATE_APP_DETAILS_KEY, mediaAppDetails)
+        override fun onConnectionSuspended(appName: String) {
+            showError(getString(
+                    R.string.connection_lost_msg,
+                    appName
+            ))
+        }
+
+        override fun onConnectionFailed(appName: String, componentName: ComponentName) {
+            showError(getString(
+                    R.string.connection_failed_hint_reject,
+                    appName,
+                    componentName.flattenToShortString()
+            ))
+        }
+
+        override fun onSetupMediaControllerError(message: String) {
+            showError(message)
+        }
+
+        override fun onTestsCreated(testList: List<TestOptionDetails>, testSuites: List<MediaAppTestSuite>) {
+            val iDToPositionMap = hashMapOf<Int, Int>()
+            for (i in testList.indices) {
+                iDToPositionMap[testList[i].id] = i
+            }
+            val testOptionAdapter = TestOptionAdapter(testList, iDToPositionMap)
+            val testOptionsList = test_options_list
+            testOptionsList.layoutManager = LinearLayoutManager(this@MediaAppTestingActivity)
+            testOptionsList.setHasFixedSize(true)
+            testOptionsList.adapter = testOptionAdapter
+
+            val testSuiteAdapter = TestSuiteAdapter(testSuites.toTypedArray())
+            val testSuiteList = test_suite_options_list
+            testSuiteList.layoutManager = LinearLayoutManager(this@MediaAppTestingActivity)
+            testSuiteList.setHasFixedSize(true)
+            testSuiteList.adapter = testSuiteAdapter
+        }
+
+        override fun onControllerPlaybackStateChanged(playbackState: String) {
+            playbackStateText.text = playbackState
+        }
+
+        override fun onControllerMetadataChanged(metadata: String) {
+            metadataText.text = metadata
+        }
+
+        override fun onControllerRepeatModeChanged(repeatMode: String) {
+            repeatModeText.text = repeatMode
+        }
+
+        override fun onControllerShuffleModeChanged(shuffleMode: String) {
+            shuffleModeText.text = shuffleMode
+        }
+
+        override fun onControllerQueueTitleChanged(title: CharSequence?) {
+            queueTitleText.text = title
+        }
+
+        override fun onControllerQueueChanged(queue: MutableList<MediaSessionCompat.QueueItem>?) {
+            queueText.text = getString(R.string.queue_size, queue?.size ?: 0)
+            queueText.setTextAppearance(applicationContext, R.style.SubText)
+            populateQueue(queue)
+        }
     }
 
-    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
-        super.onRestoreInstanceState(savedInstanceState)
-
-        mediaAppDetails = savedInstanceState.getParcelable(STATE_APP_DETAILS_KEY)
+    private fun populateQueue(_queue: MutableList<MediaSessionCompat.QueueItem>?) {
+        val queue = _queue ?: emptyList<MediaSessionCompat.QueueItem>().toMutableList()
+        val queueItemAdapter = QueueItemAdapter(queue)
+        val queueList = queue_item_list
+        queueList.layoutManager = object : LinearLayoutManager(this) {
+            override fun canScrollVertically(): Boolean = false
+        }
+        queueList.adapter = queueItemAdapter
     }
 
     private fun showToast(message: String) {
@@ -313,23 +351,28 @@ class MediaAppTestingActivity : AppCompatActivity() {
             return true
         }
 
-        if (item.itemId == R.id.logs_toggle) {
-            if (printLogsFormatted) {
-                item.icon = ContextCompat.getDrawable(this, R.drawable.ic_parsable_logs_24dp)
-                Log.i(TAG, getString(R.string.logs_activate_parsable))
-                showToast(getString(R.string.logs_activate_parsable))
-                printLogsFormatted = false
-            } else {
-                item.icon = ContextCompat.getDrawable(this, R.drawable.ic_formatted_logs_24dp)
-                Log.i(TAG, getString(R.string.logs_activate_formatted))
-                showToast(getString(R.string.logs_activate_formatted))
-                printLogsFormatted = true
+        mediaAppTestService?.let {
+            if (item.itemId == R.id.logs_toggle) {
+                if (mediaAppTestService!!.getPrintLogsFormatted()) {
+                    item.icon = ContextCompat.getDrawable(this, R.drawable.ic_parsable_logs_24dp)
+                    Log.i(TAG, getString(R.string.logs_activate_parsable))
+                    showToast(getString(R.string.logs_activate_parsable))
+                    mediaAppTestService!!.setPrintLogsFormatted(false)
+                } else {
+                    item.icon = ContextCompat.getDrawable(this, R.drawable.ic_formatted_logs_24dp)
+                    Log.i(TAG, getString(R.string.logs_activate_formatted))
+                    showToast(getString(R.string.logs_activate_formatted))
+                    mediaAppTestService!!.setPrintLogsFormatted(true)
+                }
+            } else if (item.itemId == R.id.logs_trigger) {
+                mediaAppTestService!!.logCurrentController()
+                Log.i(TAG, getString(R.string.logs_triggered))
+                showToast(getString(R.string.logs_triggered))
             }
-        } else if (item.itemId == R.id.logs_trigger) {
-            logCurrentController()
-            Log.i(TAG, getString(R.string.logs_triggered))
-            showToast(getString(R.string.logs_triggered))
+            return true
         }
+        Log.i(TAG, getString(R.string.tests_service_not_bound))
+        showToast(getString(R.string.tests_service_not_bound))
 
         return true
     }
@@ -340,103 +383,6 @@ class MediaAppTestingActivity : AppCompatActivity() {
             val toolbarIcon = BitmapUtils.createToolbarIcon(resources, icon)
             actionBar.setIcon(BitmapDrawable(resources, toolbarIcon))
             actionBar.title = name
-        }
-    }
-
-    private fun setupMedia() {
-        // setupMedia() is only called when mediaAppDetails is not null, so this should always
-        // skip the if function block
-        val appDetails = mediaAppDetails
-        if (appDetails == null) {
-            Log.e(TAG, getString(R.string.setup_media_error_msg))
-            showError(getString(R.string.connection_failed_msg, "!Unknown App Name!"))
-            return
-        }
-
-        when {
-            appDetails.componentName != null -> {
-                mediaBrowser = MediaBrowserCompat(this, appDetails.componentName,
-                        object : MediaBrowserCompat.ConnectionCallback() {
-                            override fun onConnected() {
-                                connectionErrorText.visibility = View.GONE
-                                setupMediaController(true)
-                            }
-
-                            override fun onConnectionSuspended() {
-                                showError(getString(
-                                        R.string.connection_lost_msg,
-                                        appDetails.appName
-                                ))
-                            }
-
-                            override fun onConnectionFailed() {
-                                showError(getString(
-                                        R.string.connection_failed_hint_reject,
-                                        appDetails.appName,
-                                        appDetails.componentName.flattenToShortString()
-                                ))
-                            }
-                        }, null).apply { connect() }
-            }
-            appDetails.sessionToken != null -> setupMediaController(false)
-            else -> showError(getString(R.string.connection_failed_hint_setup, appDetails.appName))
-        }
-    }
-
-    private fun setupMediaController(useTokenFromBrowser: Boolean) {
-        try {
-            val token: MediaSessionCompat.Token
-            // setupMediaController() is only called either immediately after the mediaBrowser is
-            // connected or if mediaAppDetails contains a sessionToken.
-            if (useTokenFromBrowser) {
-                val browser = mediaBrowser
-                if (browser != null) {
-                    token = browser.sessionToken
-                } else {
-                    Log.e(TAG, getString(
-                            R.string.setup_media_controller_error_msg,
-                            "MediaBrowser"
-                    ))
-                    showError(getString(
-                            R.string.setup_media_controller_error_hint,
-                            "MediaBrowser"
-                    ))
-                    return
-                }
-            } else {
-                val appDetails = mediaAppDetails
-                if (appDetails != null) {
-                    token = appDetails.sessionToken
-                } else {
-                    Log.e(TAG, getString(
-                            R.string.setup_media_controller_error_msg,
-                            "MediaAppDetails"
-                    ))
-                    showError(getString(
-                            R.string.setup_media_controller_error_hint,
-                            "MediaAppDetails"
-                    ))
-                    return
-                }
-            }
-
-            mediaController = MediaControllerCompat(this, token).also {
-                it.registerCallback(controllerCallback)
-
-                // Force update on connect
-                logCurrentController(it)
-            }
-
-            // Setup tests once media controller is connected
-            setupTests()
-
-            // Ensure views are visible
-            viewPager.visibility = View.VISIBLE
-
-            Log.d(TAG, getString(R.string.media_controller_created))
-        } catch (remoteException: RemoteException) {
-            Log.e(TAG, getString(R.string.media_controller_failed_msg), remoteException)
-            showToast(getString(R.string.media_controller_failed_msg))
         }
     }
 
@@ -455,8 +401,8 @@ class MediaAppTestingActivity : AppCompatActivity() {
             return ViewHolder(cardView)
         }
 
-
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+
             val testSuite = testSuites[position]
             holder.cardView.card_header.text = testSuite.testSuiteName
             holder.cardView.card_text.text = testSuite.testSuiteDescription
@@ -474,8 +420,10 @@ class MediaAppTestingActivity : AppCompatActivity() {
                         setContentView(R.layout.test_suite_configure_dialog)
                         title.text = getString(R.string.configure_dialog_title, testSuite.testSuiteName)
                         subtitle.text = testSuite.testSuiteDescription
-                        test_to_configure_list.layoutManager = LinearLayoutManager(this@MediaAppTestingActivity)
-                        test_to_configure_list.layoutParams.height = getScreenHeightPx(this@MediaAppTestingActivity) / 2
+                        test_to_configure_list.layoutManager =
+                                LinearLayoutManager(this@MediaAppTestingActivity)
+                        test_to_configure_list.layoutParams.height =
+                                getScreenHeightPx(this@MediaAppTestingActivity) / 2
                         test_to_configure_list.setHasFixedSize(true)
                         test_to_configure_list.adapter = configAdapter
 
@@ -501,28 +449,85 @@ class MediaAppTestingActivity : AppCompatActivity() {
             holder.cardView.card_button.setOnClickListener {
                 var numIter = test_suite_num_iter.text.toString().toIntOrNull()
                 if (numIter == null) {
-                    Toast.makeText(this@MediaAppTestingActivity, getText(R.string.test_suite_error_invalid_iter), Toast.LENGTH_SHORT).show()
-
+                    Toast.makeText(this@MediaAppTestingActivity,
+                            getText(R.string.test_suite_error_invalid_iter), Toast.LENGTH_SHORT)
+                            .show()
                 } else if (numIter > MAX_NUM_ITER || numIter < 1) {
-                    Toast.makeText(this@MediaAppTestingActivity, getText(R.string.test_suite_error_invalid_iter), Toast.LENGTH_SHORT).show()
-                } else if (isSuiteRunning()) {
-                    Toast.makeText(this@MediaAppTestingActivity, getText(R.string.test_suite_already_running), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MediaAppTestingActivity,
+                            getText(R.string.test_suite_error_invalid_iter), Toast.LENGTH_SHORT)
+                            .show()
                 } else {
-                    testSuites[position].runSuite(numIter)
+                    if (mediaAppTestService != null) {
+                        if (mediaAppTestService!!.isSuiteRunning()) {
+                            Toast.makeText(this@MediaAppTestingActivity,
+                                    getText(R.string.test_suite_already_running),
+                                    Toast.LENGTH_SHORT).show()
+                        } else {
+                            val testList: Array<TestOptionDetails> = testSuite.getTestList()
+                            resultsAdapter = ResultsAdapter(testList)
+                            positionToIDMap = hashMapOf<Int, Int>()
+
+                            for (i in testList.indices) {
+                                positionToIDMap[i] = testList[i].id
+                            }
+
+                            var progressBar : ProgressBar
+                            val dialog = Dialog(this@MediaAppTestingActivity)
+                            dialog.apply {
+                                setCancelable(false)
+                                requestWindowFeature(Window.FEATURE_NO_TITLE)
+                                setContentView(R.layout.run_suite_iter_dialog)
+                                progressBar =
+                                        findViewById<ProgressBar>(R.id.suite_iter_progress_bar)
+                                                .apply {
+                                                    max = numIter * testList.size
+                                                    progress = -1
+                                                }
+                                findViewById<Button>(R.id.quit_suite_iter_button)
+                                        .setOnClickListener{
+                                            testSuite.interrupt()
+                                            dismiss()
+                                        }
+                                window.setLayout(LinearLayout.LayoutParams.MATCH_PARENT,
+                                        LinearLayout.LayoutParams.WRAP_CONTENT)
+                            }.show()
+
+                            testSuite.runSuite(
+                                    numIter,
+                                    convertSharedPrefToConfigMap(testSuite.getTestList()),
+                                    onStartTest = {
+                                        progressBar.incrementProgressBy(1)
+                                    },
+                                    onFinishTestSuite = {
+                                        iDToResultsMap = it
+                                        dialog.dismiss()
+
+                                        var testSuiteResultsLayout =
+                                                test_suite_results_container as RecyclerView
+                                        testSuiteResultsLayout.layoutManager =
+                                                LinearLayoutManager(this@MediaAppTestingActivity)
+                                        testSuiteResultsLayout.setHasFixedSize(true)
+                                        testSuiteResultsLayout.adapter = resultsAdapter
+                                    })
+                        }
+                    } else {
+                        Toast.makeText(this@MediaAppTestingActivity,
+                                getText(R.string.tests_service_not_bound), Toast.LENGTH_SHORT)
+                                .show()
+                    }
                 }
             }
         }
-
         override fun getItemCount() = testSuites.size
+    }
 
-        private fun isSuiteRunning(): Boolean {
-            for (test in testSuites) {
-                if (test.suiteIsRunning()) {
-                    return true
-                }
-            }
-            return false
+    private fun convertSharedPrefToConfigMap(testList: Array<TestOptionDetails>): HashMap<String, String> {
+        val configMap = hashMapOf<String, String>()
+        val sharedPreferences = getSharedPreferences(SHARED_PREF_KEY_SUITE_CONFIG, Context.MODE_PRIVATE)
+        for (test in testList) {
+            configMap[test.name] = sharedPreferences.getString(test.name, NO_CONFIG)
         }
+        return configMap
     }
 
     // Adapter to display test suite details
@@ -575,422 +580,9 @@ class MediaAppTestingActivity : AppCompatActivity() {
         override fun getItemCount() = tests.size
     }
 
-    private fun setupTests() {
-        // setupTests() should only be called after the mediaController is connected, so this
-        // should never enter the if block
-        val controller = mediaController
-        if (controller == null) {
-            Log.e(TAG, getString(R.string.setup_tests_error_msg))
-            showToast(getString(R.string.setup_tests_error_msg))
-            return
-        }
-
-        /**
-         * Tests the play() transport control. The test can start in any state, might enter a
-         * transition state, but must eventually end in STATE_PLAYING. The test will fail for
-         * any terminal state other than the starting state and STATE_PLAYING. The test
-         * will also fail if the metadata changes unless the test began with null metadata.
-         */
-        val playTest = TestOptionDetails(
-                0,
-                getString(R.string.play_test_title),
-                getString(R.string.play_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId -> runPlayTest(testId, controller, callback) }
-
-        /**
-         * Tests the playFromSearch() transport control. The test can start in any state, might
-         * enter a transition state, but must eventually end in STATE_PLAYING with playback
-         * position at 0. The test will fail for any terminal state other than the starting state
-         * and STATE_PLAYING. This test does not perform any metadata checks.
-         */
-        val playFromSearch = TestOptionDetails(
-                1,
-                getString(R.string.play_search_test_title),
-                getString(R.string.play_search_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { query, callback, testId ->
-            runPlayFromSearchTest(
-                    testId, query, controller, callback)
-        }
-
-        /**
-         * Tests the playFromMediaId() transport control. The test can start in any state, might
-         * enter a transition state, but must eventually end in STATE_PLAYING with playback
-         * position at 0. The test will fail for any terminal state other than the starting state
-         * and STATE_PLAYING. The test will also fail if query is empty/null. This test does not
-         * perform any metadata checks.
-         */
-        val playFromMediaId = TestOptionDetails(
-                2,
-                getString(R.string.play_media_id_test_title),
-                getString(R.string.play_media_id_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                true
-        ) { query, callback, testId ->
-            runPlayFromMediaIdTest(
-                    testId, query, controller, callback)
-        }
-
-        /**
-         * Tests the playFromUri() transport control. The test can start in any state, might
-         * enter a transition state, but must eventually end in STATE_PLAYING with playback
-         * position at 0. The test will fail for any terminal state other than the starting state
-         * and STATE_PLAYING. The test will also fail if query is empty/null. This test does not
-         * perform any metadata checks.
-         */
-        val playFromUri = TestOptionDetails(
-                3,
-                getString(R.string.play_uri_test_title),
-                getString(R.string.play_uri_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                true
-        ) { query, callback, testId ->
-            runPlayFromUriTest(
-                    testId, query, controller, callback)
-        }
-
-        /**
-         * Tests the pause() transport control. The test can start in any state, but must end in
-         * STATE_PAUSED (but STATE_STOPPED is also okay if that is the state the test started with).
-         * The test will fail for any terminal state other than the starting state, STATE_PAUSED,
-         * and STATE_STOPPED. The test will also fail if the metadata changes unless the test began
-         * with null metadata.
-         */
-        val pauseTest = TestOptionDetails(
-                4,
-                getString(R.string.pause_test_title),
-                getString(R.string.pause_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId -> runPauseTest(testId, controller, callback) }
-
-        /**
-         * Tests the stop() transport control. The test can start in any state, but must end in
-         * STATE_STOPPED or STATE_NONE. The test will fail for any terminal state other than the
-         * starting state, STATE_STOPPED, and STATE_NONE. The test will also fail if the metadata
-         * changes to a non-null media item different from the original media item.
-         */
-        val stopTest = TestOptionDetails(
-                5,
-                getString(R.string.stop_test_title),
-                getString(R.string.stop_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId -> runStopTest(testId, controller, callback) }
-
-        /**
-         * Tests the skipToNext() transport control. The test can start in any state, might
-         * enter a transition state, but must eventually end in STATE_PLAYING with the playback
-         * position at 0 if a new media item is started or in the starting state if the media item
-         * doesn't change. The test will fail for any terminal state other than the starting state
-         * and STATE_PLAYING. The metadata must change, but might just "change" to be the same as
-         * the original metadata (e.g. if the next media item is the same as the current one); the
-         * test will not pass if the metadata doesn't get updated at some point.
-         */
-        val skipToNextTest = TestOptionDetails(
-                6,
-                getString(R.string.skip_next_test_title),
-                getString(R.string.skip_next_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runSkipToNextTest(
-                    testId, controller, callback)
-        }
-
-        /**
-         * Tests the skipToPrevious() transport control. The test can start in any state, might
-         * enter a transition state, but must eventually end in STATE_PLAYING with the playback
-         * position at 0 if a new media item is started or in the starting state if the media item
-         * doesn't change. The test will fail for any terminal state other than the starting state
-         * and STATE_PLAYING. The metadata must change, but might just "change" to be the same as
-         * the original metadata (e.g. if the previous media item is the same as the current one);
-         * the test will not pass if the metadata doesn't get updated at some point.
-         */
-        val skipToPrevTest = TestOptionDetails(
-                7,
-                getString(R.string.skip_prev_test_title),
-                getString(R.string.skip_prev_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runSkipToPrevTest(
-                    testId, controller, callback)
-        }
-
-        /**
-         * Tests the skipToQueueItem() transport control. The test can start in any state, might
-         * enter a transition state, but must eventually end in STATE_PLAYING with the playback
-         * position at 0 if a new media item is started or in the starting state if the media item
-         * doesn't change. The test will fail for any terminal state other than the starting state
-         * and STATE_PLAYING. The metadata must change, but might just "change" to be the same as
-         * the original metadata (e.g. if the next media item is the same as the current one); the
-         * test will not pass if the metadata doesn't get updated at some point.
-         */
-        val skipToItemTest = TestOptionDetails(
-                8,
-                getString(R.string.skip_item_test_title),
-                getString(R.string.skip_item_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                true
-        ) { query, callback, testId ->
-            runSkipToItemTest(
-                    testId, query, controller, callback)
-        }
-
-        /**
-         * Tests the seekTo() transport control. The test can start in any state, might enter a
-         * transition state, but must eventually end in a terminal state with playback position at
-         * the requested timestamp. While not required, it is expected that the test will end in
-         * the same state as it started. Metadata might change for this test if the requested
-         * timestamp is outside the bounds of the current media item. The query should either be
-         * a position in seconds or a change in position (number of seconds prepended by '+' to go
-         * forward or '-' to go backwards). The test will fail if the query can't be parsed to a
-         * Long.
-         */
-        val seekToTest = TestOptionDetails(
-                9,
-                getString(R.string.seek_test_title),
-                getString(R.string.seek_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                true
-        ) { query, callback, testId ->
-            runSeekToTest(
-                    testId, query, controller, callback)
-        }
-
-        /**
-         * Automotive and Auto shared tests
-         */
-        val browseTreeDepthTest = TestOptionDetails(
-                10,
-                getString(R.string.browse_tree_depth_test_title),
-                getString(R.string.browse_tree_depth_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                runBrowseTreeDepthTest(
-                        testId, controller, mediaBrowser, callback)
-            } else {
-                Toast.makeText(
-                        applicationContext,
-                        "This test requires minSDK 24",
-                        Toast.LENGTH_SHORT)
-                        .show()
-            }
-        }
-
-        val mediaArtworkTest = TestOptionDetails(
-                11,
-                getString(R.string.media_artwork_test_title),
-                getString(R.string.media_artwork_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                runMediaArtworkTest(
-                        testId, controller, mediaBrowser, callback)
-            } else {
-                Toast.makeText(
-                        applicationContext,
-                        "This test requires minSDK 24",
-                        Toast.LENGTH_SHORT)
-                        .show()
-            }
-        }
-
-        val contentStyleTest = TestOptionDetails(
-                12,
-                getString(R.string.content_style_test_title),
-                getString(R.string.content_style_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runContentStyleTest(
-                    testId, controller, mediaBrowser, callback)
-        }
-
-        val customActionIconTypeTest = TestOptionDetails(
-                13,
-                getString(R.string.custom_actions_icon_test_title),
-                getString(R.string.custom_actions_icon_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runCustomActionIconTypeTest(
-                    testId, applicationContext, controller, mediaAppDetails, callback)
-        }
-
-        val supportsSearchTest = TestOptionDetails(
-                14,
-                getString(R.string.search_supported_test_title),
-                getString(R.string.search_supported_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runSearchTest(
-                    testId, controller, mediaBrowser, callback)
-        }
-
-        val initialPlaybackStateTest = TestOptionDetails(
-                15,
-                getString(R.string.playback_state_test_title),
-                getString(R.string.playback_state_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runInitialPlaybackStateTest(
-                    testId, controller, callback)
-        }
-
-        /**
-         * Automotive specific tests
-         */
-        val browseTreeStructureTest = TestOptionDetails(
-                16,
-                getString(R.string.browse_tree_structure_test_title),
-                getString(R.string.browse_tree_structure_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                runBrowseTreeStructureTest(
-                        testId, controller, mediaBrowser, callback)
-            } else {
-                Toast.makeText(
-                        applicationContext,
-                        getString(R.string.test_error_minsdk),
-                        Toast.LENGTH_SHORT)
-                        .show()
-            }
-        }
-
-        val preferenceTest = TestOptionDetails(
-                17,
-                getString(R.string.preference_activity_test_title),
-                getString(R.string.preference_activity_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runPreferenceTest(
-                    testId, controller, mediaAppDetails, packageManager, callback)
-        }
-
-        val errorResolutionDataTest = TestOptionDetails(
-                18,
-                getString(R.string.error_resolution_test_title),
-                getString(R.string.error_resolution_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runErrorResolutionDataTest(
-                    testId, controller, callback)
-        }
-
-        val launcherTest = TestOptionDetails(
-                19,
-                getString(R.string.launcher_intent_test_title),
-                getString(R.string.launcher_intent_test_desc),
-                TestResult.NONE,
-                Test.NO_LOGS,
-                false
-        ) { _, callback, testId ->
-            runLauncherTest(
-                    testId, controller, mediaAppDetails, packageManager, callback)
-        }
-
-        val basicTests = arrayOf(
-
-                playFromSearch,
-                playFromMediaId,
-                playFromUri,
-                playTest,
-                pauseTest,
-                stopTest,
-                skipToNextTest,
-                skipToPrevTest,
-                skipToItemTest,
-                seekToTest
-        )
-
-        val commonTests = arrayOf(
-                browseTreeDepthTest,
-                mediaArtworkTest,
-                //TODO FIX contentStyleTest,
-                customActionIconTypeTest,
-                //TODO: FIX supportsSearchTest,
-                initialPlaybackStateTest
-        )
-
-        val automotiveTests = arrayOf(
-                browseTreeStructureTest,
-                preferenceTest,
-                errorResolutionDataTest,
-                launcherTest
-        )
-
-        var testList = basicTests
-        var testSuites: ArrayList<MediaAppTestSuite> = ArrayList()
-        var testSuiteResults = test_suite_results_container as RecyclerView
-
-        val basicTestSuite = MediaAppTestSuite("Basic Tests", "Basic media tests.", basicTests, testSuiteResults, this)
-        testSuites.add(basicTestSuite)
-        if (mediaAppDetails?.supportsAuto == true || mediaAppDetails?.supportsAutomotive == true) {
-            testList += commonTests
-            val autoTestSuite = MediaAppTestSuite("Auto Tests", "Includes support for android auto tests.", testList, testSuiteResults, this)
-            testSuites.add(autoTestSuite)
-        }
-        if (mediaAppDetails?.supportsAutomotive == true) {
-            testList += automotiveTests
-            val automotiveTestSuite = MediaAppTestSuite("Automotive Tests", "Includdes support for Android automotive tests.", testList, testSuiteResults, this)
-            testSuites.add(automotiveTestSuite)
-        }
-        val iDToPositionMap = hashMapOf<Int, Int>()
-        for (i in testList.indices) {
-            iDToPositionMap[testList[i].id] = i
-        }
-
-        val testOptionAdapter = TestOptionAdapter(testList, iDToPositionMap)
-
-        val testOptionsList = test_options_list
-        testOptionsList.layoutManager = LinearLayoutManager(this)
-        testOptionsList.setHasFixedSize(true)
-        testOptionsList.adapter = testOptionAdapter
-
-        // Set up test suites display.
-        val testSuiteAdapter = TestSuiteAdapter(testSuites.toTypedArray())
-        val testSuiteList = test_suite_options_list
-        testSuiteList.layoutManager = LinearLayoutManager(this)
-        testSuiteList.setHasFixedSize(true)
-        testSuiteList.adapter = testSuiteAdapter
-    }
-
     // Adapter to display test details
     inner class TestOptionAdapter(
-            private val tests: Array<TestOptionDetails>,
+            private val tests: List<TestOptionDetails>,
             private val iDToPositionMap: HashMap<Int, Int>
     ) : RecyclerView.Adapter<TestOptionAdapter.ViewHolder>() {
         inner class ViewHolder(val cardView: CardView) : RecyclerView.ViewHolder(cardView)
@@ -1045,10 +637,10 @@ class MediaAppTestingActivity : AppCompatActivity() {
     }
 
     // Adapter to display Queue Item information
-    class QueueItemAdapter(
+    inner class QueueItemAdapter(
             private val items: MutableList<MediaSessionCompat.QueueItem>
     ) : RecyclerView.Adapter<QueueItemAdapter.ViewHolder>() {
-        class ViewHolder(val linearLayout: LinearLayout) : RecyclerView.ViewHolder(linearLayout)
+        inner class ViewHolder(val linearLayout: LinearLayout) : RecyclerView.ViewHolder(linearLayout)
 
         override fun onCreateViewHolder(
                 parent: ViewGroup,
@@ -1092,145 +684,117 @@ class MediaAppTestingActivity : AppCompatActivity() {
         override fun getItemCount() = items.size
     }
 
-    private fun populateQueue(_queue: MutableList<MediaSessionCompat.QueueItem>?) {
-        val queue = _queue ?: emptyList<MediaSessionCompat.QueueItem>().toMutableList()
-        val queueItemAdapter = QueueItemAdapter(queue)
-        val queueList = queue_item_list
-        queueList.layoutManager = object : LinearLayoutManager(this) {
-            override fun canScrollVertically(): Boolean = false
-        }
-        queueList.adapter = queueItemAdapter
-    }
+    /**
+     *  Adapter to display each test and the number of associated successes.
+     */
+    inner class ResultsAdapter(
+            private val tests: Array<TestOptionDetails>
+    ) : RecyclerView.Adapter<ResultsAdapter.ViewHolder>() {
+        inner class ViewHolder(val cardView: CardView) : RecyclerView.ViewHolder(cardView)
 
-    private fun logCurrentController(controller: MediaControllerCompat? = mediaController) {
-        if (controller == null) {
-            showToast("Null MediaController")
-            return
+        fun update() {
+
         }
 
-        controllerCallback.run {
-            onPlaybackStateChanged(controller.playbackState)
-            onMetadataChanged(controller.metadata)
-            onRepeatModeChanged(controller.repeatMode)
-            onShuffleModeChanged(controller.shuffleMode)
-            onQueueTitleChanged(controller.queueTitle)
-            onQueueChanged(controller.queue)
+        override fun onCreateViewHolder(
+                parent: ViewGroup,
+                viewType: Int
+        ): ResultsAdapter.ViewHolder {
+            val cardView = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.media_test_suite_result, parent, false) as CardView
+            return ViewHolder(cardView)
         }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val testID = positionToIDMap[position]!!
+            val testCaseResults = iDToResultsMap[testID]!!
+            holder.cardView.card_header.text = tests[position].name
+            holder.cardView.card_text.text = tests[position].desc
+            holder.cardView.total_tests.text = testCaseResults.totalRuns.toString()
+            holder.cardView.tests_passing.text = testCaseResults.numPassing.toString()
+            if (testCaseResults.totalRuns == 0) {
+                holder.cardView.setOnClickListener{}
+                holder.cardView.tests_passing_header.text = getString(R.string.test_suite_config_needed_header)
+                holder.cardView.setCardBackgroundColor(Color.GRAY)
+                return
+            }
+            val passPercentage = testCaseResults.numPassing.toFloat() / testCaseResults.totalRuns.toFloat()
+            holder.cardView.setCardBackgroundColor((argbEvaluator.evaluate(
+                    passPercentage,
+                    ResourcesCompat.getColor(resources, R.color.test_result_fail, null),
+                    ResourcesCompat.getColor(resources, R.color.test_result_pass, null) )) as Int)
+            val onResultsClickedListener = OnResultsClickedListener(testID, tests[position].name, tests[position].desc, this@MediaAppTestingActivity)
+            holder.cardView.setOnClickListener(onResultsClickedListener)
+        }
+
+        override fun getItemCount() = tests.size
     }
 
     /**
-     * This callback will log any changes in the playback state or metadata of the mediacontroller
+     *  Listener for when a specific test result is clicked from the results adapter. Shows logs
+     * for runs associated with the specific tests.
      */
-    private var controllerCallback: MediaControllerCompat.Callback =
-            object : MediaControllerCompat.Callback() {
-                override fun onPlaybackStateChanged(state: PlaybackStateCompat?) {
-                    val s = formatPlaybackState(state)
-                    if (printLogsFormatted) {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_formatted,
-                                getString(R.string.tests_info_state),
-                                s
-                        ))
-                    } else {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_parsable,
-                                getString(R.string.tests_info_state),
-                                formatPlaybackStateParsable(state)
-                        ))
+    inner class OnResultsClickedListener(private val testId: Int, private val name: String, private val description: String, val context: Context?) : View.OnClickListener {
+
+        override fun onClick(p0: View?) {
+            var dialog = Dialog(context).apply {
+                requestWindowFeature(Window.FEATURE_NO_TITLE)
+                setContentView(R.layout.test_suite_results_dialog)
+                findViewById<TextView>(R.id.results_title).text = name
+                findViewById<TextView>(R.id.results_subtitle).text = description
+
+                // Add the passing text log section
+                if(iDToResultsMap[testId]!!.passingLogs.isNotEmpty()) {
+                    val passing_results_log = findViewById<LinearLayout>(R.id.passing_results_log)
+                    passing_results_log.removeAllViews()
+                    for (logsList in iDToResultsMap[testId]!!.passingLogs) {
+                        passing_results_log.addView(TextView(context).apply {
+                            text = resources.getString(R.string.test_iter_divider)
+                            setTextAppearance(context, R.style.SubHeader)
+                            gravity = Gravity.CENTER
+                            setTextColor(ResourcesCompat.getColor(resources, R.color.test_result_pass, null))
+                        })
+                        for (line in logsList) {
+                            var logLine = TextView(context).apply {
+                                text = line
+
+                                setTextAppearance(context, R.style.SubText)
+                            }
+                            passing_results_log.addView(logLine)
+                        }
                     }
-                    playbackStateText.text = s
+                } else {
+                    findViewById<TextView>(R.id.passing_logs_header).visibility = View.GONE
                 }
 
-                override fun onMetadataChanged(metadata: MediaMetadataCompat?) {
-                    val s = formatMetadata(metadata)
-                    if (printLogsFormatted) {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_formatted,
-                                getString(R.string.tests_info_metadata),
-                                s
-                        ))
-                    } else {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_parsable,
-                                getString(R.string.tests_info_metadata),
-                                formatMetadataParsable(metadata)
-                        ))
+                // Add the passing text log section
+                if(iDToResultsMap[testId]!!.failingLogs.isNotEmpty()) {
+                    val failing_results_log = findViewById<LinearLayout>(R.id.failing_results_log)
+                    failing_results_log.removeAllViews()
+                    for (logsList in iDToResultsMap[testId]!!.failingLogs) {
+                        failing_results_log.addView(TextView(context).apply {
+                            text = resources.getString(R.string.test_iter_divider)
+                            setTextAppearance(context, R.style.SubHeader)
+                            gravity = Gravity.CENTER
+                            setTextColor(ResourcesCompat.getColor(resources, R.color.test_result_fail, null))
+                        })
+                        for (line in logsList) {
+                            var logLine = TextView(context).apply {
+                                text = line
+                                setTextAppearance(context, R.style.SubText)
+                            }
+                            failing_results_log.addView(logLine)
+                        }
                     }
-                    metadataText.text = s
                 }
-
-                override fun onRepeatModeChanged(repeatMode: Int) {
-                    val s = repeatModeToName(repeatMode)
-                    if (printLogsFormatted) {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_formatted,
-                                getString(R.string.tests_info_repeat),
-                                s
-                        ))
-                    } else {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_parsable,
-                                getString(R.string.tests_info_repeat),
-                                repeatMode.toString()
-                        ))
-                    }
-                    repeatModeText.text = s
+                else {
+                    findViewById<TextView>(R.id.failing_logs_header).visibility = View.GONE
                 }
-
-                override fun onShuffleModeChanged(shuffleMode: Int) {
-                    val s = shuffleModeToName(shuffleMode)
-                    if (printLogsFormatted) {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_formatted,
-                                getString(R.string.tests_info_shuffle),
-                                s
-                        ))
-                    } else {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_parsable,
-                                getString(R.string.tests_info_shuffle),
-                                shuffleMode.toString()
-                        ))
-                    }
-                    shuffleModeText.text = s
-                }
-
-                override fun onQueueTitleChanged(title: CharSequence?) {
-                    if (printLogsFormatted) {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_formatted,
-                                getString(R.string.tests_info_queue_title),
-                                title
-                        ))
-                    } else {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_parsable,
-                                getString(R.string.tests_info_queue_title),
-                                title
-                        ))
-                    }
-                    queueTitleText.text = title
-                }
-
-                override fun onQueueChanged(queue: MutableList<MediaSessionCompat.QueueItem>?) {
-                    if (printLogsFormatted) {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_formatted,
-                                getString(R.string.tests_info_queue),
-                                queueToString(queue)
-                        ))
-                    } else {
-                        Log.i(TAG, getString(
-                                R.string.logs_controller_info_parsable,
-                                getString(R.string.tests_info_queue),
-                                queueToStringParsable(queue)
-                        ))
-                    }
-                    queueText.text = getString(R.string.queue_size, queue?.size ?: 0)
-                    queueText.setTextAppearance(applicationContext, R.style.SubText)
-                    populateQueue(queue)
-                }
-            }
+                findViewById<ScrollView>(R.id.results_scroll_view).layoutParams.height = (MediaAppTestingActivity.getScreenHeightPx(context) / 2).toInt()
+                findViewById<Button>(R.id.close_results_button).setOnClickListener(View.OnClickListener { dismiss() })
+            }.show()
+        }
+    }
 
     companion object {
 

--- a/mediacontroller/src/main/java/com/example/android/mediacontroller/TestUtils.kt
+++ b/mediacontroller/src/main/java/com/example/android/mediacontroller/TestUtils.kt
@@ -409,4 +409,3 @@ fun formatMillisToSeconds(value: Long?): String {
         "%.2fs".format(it / 1000f)
     } ?: "null"
 }
-

--- a/mediacontroller/src/main/res/drawable/ic_android.xml
+++ b/mediacontroller/src/main/res/drawable/ic_android.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:height="64dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="64dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.6,9.48l1.84,-3.18c0.16,-0.31 0.04,-0.69 -0.26,-0.85c-0.29,-0.15 -0.65,-0.06 -0.83,0.22l-1.88,3.24c-2.86,-1.21 -6.08,-1.21 -8.94,0L5.65,5.67c-0.19,-0.29 -0.58,-0.38 -0.87,-0.2C4.5,5.65 4.41,6.01 4.56,6.3L6.4,9.48C3.3,11.25 1.28,14.44 1,18h22C22.72,14.44 20.7,11.25 17.6,9.48zM7,15.25c-0.69,0 -1.25,-0.56 -1.25,-1.25c0,-0.69 0.56,-1.25 1.25,-1.25S8.25,13.31 8.25,14C8.25,14.69 7.69,15.25 7,15.25zM17,15.25c-0.69,0 -1.25,-0.56 -1.25,-1.25c0,-0.69 0.56,-1.25 1.25,-1.25s1.25,0.56 1.25,1.25C18.25,14.69 17.69,15.25 17,15.25z"/>
+</vector>

--- a/mediacontroller/src/main/res/values/strings.xml
+++ b/mediacontroller/src/main/res/values/strings.xml
@@ -141,6 +141,8 @@
     <string name="bottom_nav_test_text">Tests</string>
     <string name="test_suite_nav_text">Test Suites</string>
 
+    <string name="notification_message">Running media controller test</string>
+
     <!--
     The order of these strings must match the order of the constants
     declared in MediaAppControllerActivity.AudioFocusHelper (FOCUS_TYPES).

--- a/mediacontroller/src/main/res/values/testing_strings.xml
+++ b/mediacontroller/src/main/res/values/testing_strings.xml
@@ -15,6 +15,9 @@
   -->
 
 <resources>
+    <!-- Test service -->
+    <string name="tests_service_not_bound">Currently not bound to test service.</string>
+
     <!-- MediaController Properties -->
     <string name="tests_info_state">Playback State</string>
     <string name="tests_info_metadata">Metadata</string>


### PR DESCRIPTION
- Create MediaAppTestService.kt, which will start a foreground service with a notification when it is started.
- Create a binder/callback communication channel between MediaAppTestService and MediaAppTestingActivity.
- Separate testing logic from MediaAppTestingActivity and MediaAppTestSuite and move it into MediaAppTestService.

TODO: Need to remove all context-related code from MediaAppTestService.