### PR TITLE
Fix build-breaking linter error from android:tint

### DIFF
--- a/mediacontroller/src/main/res/layout/media_custom_control.xml
+++ b/mediacontroller/src/main/res/layout/media_custom_control.xml
@@ -14,6 +14,7 @@
   limitations under the License.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -27,7 +28,7 @@
         android:layout_gravity="center_vertical"
         android:layout_marginEnd="@dimen/margin_small"
         android:scaleType="fitCenter"
-        android:tint="@color/text_dark"
+        app:tint="@color/text_dark"
         tools:ignore="ContentDescription" />
 
     <LinearLayout


### PR DESCRIPTION
Apply changes suggested by linter error:

 Error: Must use app:tint instead of android:tint [UseAppTint from appcompat-1.3.1]                                                                  
        android:tint="@color/text_dark"                    
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                               